### PR TITLE
Fixes forced args to soxi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ if __name__ == "__main__":
         license='MIT',
 
         install_requires=[
+            'pyyaml'
         ],
 
         extras_require={

--- a/sox/core.py
+++ b/sox/core.py
@@ -2,6 +2,7 @@
 import logging
 import subprocess
 from subprocess import CalledProcessError
+import yaml
 
 from . import NO_SOX
 
@@ -92,28 +93,29 @@ def _get_valid_formats():
 VALID_FORMATS = _get_valid_formats()
 
 
-def soxi(filepath, argument):
+def soxi(filepath, argument=None):
     ''' Base call to Soxi.
 
     Parameters
     ----------
     filepath : str
         Path to audio file.
+
     argument : str
         Argument to pass to Soxi.
 
     Returns
     -------
-    shell_output : str
-        command line output of Soxi
-
+    shell_output : str, or dict if argument is None
+        Command line output of Soxi
     '''
 
-    if argument not in SOXI_ARGS:
+    if argument is not None and argument not in SOXI_ARGS:
         raise ValueError("Invalid argument '{}' to Soxi".format(argument))
 
     args = ['soxi']
-    args.append("-{}".format(argument))
+    if argument:
+        args.append("-{}".format(argument))
     args.append(enquote_filepath(filepath))
 
     try:
@@ -127,7 +129,11 @@ def soxi(filepath, argument):
 
     shell_output = shell_output.decode("utf-8")
 
-    return str(shell_output).strip('\n')
+    if argument is None:
+        result = yaml.load(str(shell_output))
+    else:
+        result = str(shell_output).strip('\n')
+    return result
 
 
 def play(args):
@@ -175,6 +181,7 @@ def play(args):
 class SoxiError(Exception):
     '''Exception to be raised when SoXi exits with non-zero status.
     '''
+
     def __init__(self, *args, **kwargs):
         Exception.__init__(self, *args, **kwargs)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -111,7 +111,7 @@ class TestSoxi(unittest.TestCase):
 
     def test_invalid_argument(self):
         with self.assertRaises(ValueError):
-            core.soxi(INPUT_FILE, None)
+            core.soxi(INPUT_FILE, 'booger')
 
     def test_nonexistent_file(self):
         with self.assertRaises(SoxiError):
@@ -124,6 +124,20 @@ class TestSoxi(unittest.TestCase):
     def test_soxi_error(self):
         with self.assertRaises(SoxiError):
             core.soxi(INPUT_FILE_CORRUPT, 's')
+
+    def test_null_arg(self):
+        actual = core.soxi(INPUT_FILE, None)
+        expected = {
+            'Bit Rate': '706k',
+            'Channels': 1,
+            'Duration': '00:00:10.00 = 441000 samples = 750 CDDA sectors',
+            'File Size': '882k',
+            'Input File': INPUT_FILE,
+            'Precision': '16-bit',
+            'Sample Encoding': '16-bit Signed Integer PCM',
+            'Sample Rate': 44100}
+
+        self.assertEqual(expected, actual)
 
 
 @unittest.skip("Tests pass on local machine and fail on remote.")


### PR DESCRIPTION
`soxi` was requiring an argument, which isn't really necessary. This PR generalizes that, and tests that it works.