### PR TITLE
Filepath check update for noiseprof

### DIFF
--- a/sox/file_info.py
+++ b/sox/file_info.py
@@ -259,7 +259,7 @@ def validate_output_file(output_filepath):
 
     nowrite_conditions = [
         bool(os.path.dirname(output_filepath)) or\
-            not os.access(os.path.join(os.getcwd(), output_filepath)),
+            not os.access(os.getcwd(), os.W_OK),
         not os.access(os.path.dirname(output_filepath), os.W_OK)]
 
     if all(nowrite_conditions):

--- a/sox/file_info.py
+++ b/sox/file_info.py
@@ -258,7 +258,8 @@ def validate_output_file(output_filepath):
     '''
 
     nowrite_conditions = [
-        bool(os.path.dirname(output_filepath)),
+        bool(os.path.dirname(output_filepath)) or\
+            not os.access(os.path.join(os.getcwd(), output_filepath)),
         not os.access(os.path.dirname(output_filepath), os.W_OK)]
 
     if all(nowrite_conditions):

--- a/sox/transform.py
+++ b/sox/transform.py
@@ -1877,8 +1877,11 @@ class Transformer(object):
         if os.path.isdir(profile_path):
             raise ValueError("profile_path {} is a directory, but filename should be specified.")
         
-        _abs_profile_path = os.path.dirname(profile_path) and\
-            profile_path or os.path.join(os.getcwd(), profile_path)
+        if os.path.dirname(profile_path) == '' and profile_path != '':
+            _abs_profile_path = os.path.join(os.getcwd(), profile_path)
+        else:
+            _abs_profile_path = profile_path
+                
         if not os.access(os.path.dirname(_abs_profile_path), os.W_OK):
             raise IOError("profile_path {} is not writeable.".format(_abs_profile_path))
 

--- a/sox/transform.py
+++ b/sox/transform.py
@@ -1875,9 +1875,10 @@ class Transformer(object):
 
         '''
         if os.path.isdir(profile_path):
-            raise ValueError("profile_path {} is a directory, but should be a file")
+            raise ValueError("profile_path {} is a directory, but filename should be specified.")
         
-        if not os.access(os.path.dirname(profile_path), os.W_OK):
+        if (bool(os.path.dirname(profile_path)) and
+            not os.access(os.path.dirname(profile_path), os.W_OK)):
             raise IOError("profile_path {} is not writeable.".format(profile_path))
 
         effect_args = ['noiseprof', profile_path]

--- a/sox/transform.py
+++ b/sox/transform.py
@@ -1877,9 +1877,10 @@ class Transformer(object):
         if os.path.isdir(profile_path):
             raise ValueError("profile_path {} is a directory, but filename should be specified.")
         
-        if (bool(os.path.dirname(profile_path)) and
-            not os.access(os.path.dirname(profile_path), os.W_OK)):
-            raise IOError("profile_path {} is not writeable.".format(profile_path))
+        _abs_profile_path = os.path.dirname(profile_path) and\
+            profile_path or os.path.join(os.getcwd(), profile_path)
+        if not os.access(os.path.dirname(_abs_profile_path), os.W_OK):
+            raise IOError("profile_path {} is not writeable.".format(_abs_profile_path))
 
         effect_args = ['noiseprof', profile_path]
         self.build(input_filepath, None, extra_args=effect_args)

--- a/sox/version.py
+++ b/sox/version.py
@@ -3,4 +3,4 @@
 """Version info"""
 
 short_version = '1.2'
-version = '1.2.8'
+version = '1.2.9'

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -2679,6 +2679,14 @@ class TestTransformerNoiseprof(unittest.TestCase):
         with self.assertRaises(IOError):
             tfm.noiseprof(INPUT_FILE, '/usr/noise.prof')
 
+    def test_noise_prof_invalid_cwd(self):
+        tfm = new_transformer()
+        _cwd = os.getcwd()
+        os.chdir('/')
+        with self.assertRaises(IOError):
+            tfm.noiseprof(INPUT_FILE, 'noise.prof')
+        os.chdir(_cwd)
+
 
 class TestTransformerNoisered(unittest.TestCase):
     


### PR DESCRIPTION
Update `noiseprof` filepath check. The previous version did not consider `profile_path='noise.prof'` is legal.