### PR TITLE
Fixed enquote on filepath for stats

### DIFF
--- a/sox/file_info.py
+++ b/sox/file_info.py
@@ -6,6 +6,7 @@ import os
 from .core import VALID_FORMATS
 from .core import soxi
 from .core import sox
+from .core import enquote_filepath
 
 
 def bitrate(input_filepath):
@@ -361,7 +362,7 @@ def _stat_call(filepath):
         Sox output from stderr.
     '''
     validate_input_file(filepath)
-    args = ['sox', filepath, '-n', 'stat']
+    args = ['sox', enquote_filepath(filepath), '-n', 'stat']
     _, _, stat_output = sox(args)
     return stat_output
 

--- a/sox/version.py
+++ b/sox/version.py
@@ -3,4 +3,4 @@
 """Version info"""
 
 short_version = '1.3'
-version = '1.3.0'
+version = '1.3.1'


### PR DESCRIPTION
When having a space in filepath, the sox.file_info.info() command is erroring.
Btw - thanks for great work. Very useful and well done wrapper around sox.