### PR TITLE
Switch to using a named logger so callers can configure log levels.

### DIFF
--- a/sox/__init__.py
+++ b/sox/__init__.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 """ init method for sox module """
-import logging
-logger = logging.getLogger('sox')
+from .log import logger
 import os
 
 # Check that SoX is installed and callable

--- a/sox/__init__.py
+++ b/sox/__init__.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python
 """ init method for sox module """
 import logging
+logger = logging.getLogger('sox')
 import os
 
 # Check that SoX is installed and callable
 NO_SOX = False
 if not len(os.popen('sox -h').readlines()):
-    logging.warning("""SoX could not be found!
+    logger.warning("""SoX could not be found!
 
     If you do not have SoX, proceed here:
      - - - http://sox.sourceforge.net/ - - -

--- a/sox/combine.py
+++ b/sox/combine.py
@@ -6,12 +6,10 @@ This module requires that SoX is installed.
 '''
 
 from __future__ import print_function
-import logging
-logger = logging.getLogger('sox')
-
 
 from . import file_info
 from . import core
+from .log import logger
 from .core import ENCODING_VALS
 from .core import enquote_filepath
 from .core import is_number

--- a/sox/combine.py
+++ b/sox/combine.py
@@ -7,6 +7,7 @@ This module requires that SoX is installed.
 
 from __future__ import print_function
 import logging
+logger = logging.getLogger('sox')
 
 
 from . import file_info
@@ -81,7 +82,7 @@ class Combiner(Transformer):
         try:
             _validate_file_formats(input_filepath_list, combine_type)
         except SoxiError:
-            logging.warning("unable to validate file formats.")
+            logger.warning("unable to validate file formats.")
 
         args = []
         args.extend(self.globals)
@@ -101,14 +102,14 @@ class Combiner(Transformer):
                 "Stdout: {}\nStderr: {}".format(out, err)
             )
         else:
-            logging.info(
+            logger.info(
                 "Created %s with combiner %s and  effects: %s",
                 output_filepath,
                 combine_type,
                 " ".join(self.effects_log)
             )
             if out is not None:
-                logging.info("[SoX] {}".format(out))
+                logger.info("[SoX] {}".format(out))
             return True
 
     def preview(self, input_filepath_list, combine_type, input_volumes=None):
@@ -378,14 +379,14 @@ def _build_input_format_list(input_filepath_list, input_volumes=None,
     else:
         n_volumes = len(input_volumes)
         if n_volumes < n_inputs:
-            logging.warning(
+            logger.warning(
                 'Volumes were only specified for %s out of %s files.'
                 'The last %s files will remain at their original volumes.',
                 n_volumes, n_inputs, n_inputs - n_volumes
             )
             vols = input_volumes + [1] * (n_inputs - n_volumes)
         elif n_volumes > n_inputs:
-            logging.warning(
+            logger.warning(
                 '%s volumes were specified but only %s input files exist.'
                 'The last %s volumes will be ignored.',
                 n_volumes, n_inputs, n_volumes - n_inputs
@@ -400,7 +401,7 @@ def _build_input_format_list(input_filepath_list, input_volumes=None,
     else:
         n_fmts = len(input_format)
         if n_fmts < n_inputs:
-            logging.warning(
+            logger.warning(
                 'Input formats were only specified for %s out of %s files.'
                 'The last %s files will remain unformatted.',
                 n_fmts, n_inputs, n_inputs - n_fmts
@@ -408,7 +409,7 @@ def _build_input_format_list(input_filepath_list, input_volumes=None,
             fmts = [f for f in input_format]
             fmts.extend([[] for _ in range(n_inputs - n_fmts)])
         elif n_fmts > n_inputs:
-            logging.warning(
+            logger.warning(
                 '%s Input formats were specified but only %s input files exist'
                 '. The last %s formats will be ignored.',
                 n_fmts, n_inputs, n_fmts - n_inputs

--- a/sox/core.py
+++ b/sox/core.py
@@ -1,5 +1,8 @@
 '''Base module for calling SoX '''
 import logging
+
+logger = logging.getLogger('sox')
+
 import subprocess
 from subprocess import CalledProcessError
 
@@ -43,7 +46,7 @@ def sox(args):
 
     try:
         command = ' '.join(args)
-        logging.info("Executing: %s", command)
+        logger.info("Executing: %s", command)
 
         process_handle = subprocess.Popen(
             command, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
@@ -58,9 +61,9 @@ def sox(args):
         return status, out, err
 
     except OSError as error_msg:
-        logging.error("OSError: SoX failed! %s", error_msg)
+        logger.error("OSError: SoX failed! %s", error_msg)
     except TypeError as error_msg:
-        logging.error("TypeError: %s", error_msg)
+        logger.error("TypeError: %s", error_msg)
     return 1, None, None
 
 
@@ -125,7 +128,7 @@ def soxi(filepath, argument):
             shell=True, stderr=subprocess.PIPE
         )
     except CalledProcessError as cpe:
-        logging.info("Soxi error message: {}".format(cpe.output))
+        logger.info("Soxi error message: {}".format(cpe.output))
         raise SoxiError("Soxi failed with exit code {}".format(cpe.returncode))
 
     shell_output = shell_output.decode("utf-8")
@@ -154,24 +157,24 @@ def play(args):
         args[0] = "play"
 
     try:
-        logging.info("Executing: %s", " ".join(args))
+        logger.info("Executing: %s", " ".join(args))
         process_handle = subprocess.Popen(
             args, stdout=subprocess.PIPE, stderr=subprocess.PIPE
         )
 
         status = process_handle.wait()
         if process_handle.stderr is not None:
-            logging.info(process_handle.stderr)
+            logger.info(process_handle.stderr)
 
         if status == 0:
             return True
         else:
-            logging.info("Play returned with error code %s", status)
+            logger.info("Play returned with error code %s", status)
             return False
     except OSError as error_msg:
-        logging.error("OSError: Play failed! %s", error_msg)
+        logger.error("OSError: Play failed! %s", error_msg)
     except TypeError as error_msg:
-        logging.error("TypeError: %s", error_msg)
+        logger.error("TypeError: %s", error_msg)
     return False
 
 

--- a/sox/core.py
+++ b/sox/core.py
@@ -1,7 +1,5 @@
 '''Base module for calling SoX '''
-import logging
-
-logger = logging.getLogger('sox')
+from .log import logger
 
 import subprocess
 from subprocess import CalledProcessError

--- a/sox/file_info.py
+++ b/sox/file_info.py
@@ -1,6 +1,9 @@
 ''' Audio file info computed by soxi.
 '''
 import logging
+
+logger = logging.getLogger('sox')
+
 import os
 
 from .core import VALID_FORMATS
@@ -27,7 +30,7 @@ def bitrate(input_filepath):
     validate_input_file(input_filepath)
     output = soxi(input_filepath, 'b')
     if output == '0':
-        logging.warning("Bitrate unavailable for %s", input_filepath)
+        logger.warning("Bitrate unavailable for %s", input_filepath)
     return int(output)
 
 
@@ -88,7 +91,7 @@ def duration(input_filepath):
     validate_input_file(input_filepath)
     output = soxi(input_filepath, 'D')
     if output == '0':
-        logging.warning("Duration unavailable for %s", input_filepath)
+        logger.warning("Duration unavailable for %s", input_filepath)
 
     return float(output)
 
@@ -149,7 +152,7 @@ def num_samples(input_filepath):
     validate_input_file(input_filepath)
     output = soxi(input_filepath, 's')
     if output == '0':
-        logging.warning("Number of samples unavailable for %s", input_filepath)
+        logger.warning("Number of samples unavailable for %s", input_filepath)
     return int(output)
 
 
@@ -216,8 +219,8 @@ def validate_input_file(input_filepath):
         )
     ext = file_extension(input_filepath)
     if ext not in VALID_FORMATS:
-        logging.info("Valid formats: %s", " ".join(VALID_FORMATS))
-        logging.warning(
+        logger.info("Valid formats: %s", " ".join(VALID_FORMATS))
+        logger.warning(
             "This install of SoX cannot process .{} files.".format(ext)
         )
 
@@ -270,13 +273,13 @@ def validate_output_file(output_filepath):
 
     ext = file_extension(output_filepath)
     if ext not in VALID_FORMATS:
-        logging.info("Valid formats: %s", " ".join(VALID_FORMATS))
-        logging.warning(
+        logger.info("Valid formats: %s", " ".join(VALID_FORMATS))
+        logger.warning(
             "This install of SoX cannot process .{} files.".format(ext)
         )
 
     if os.path.exists(output_filepath):
-        logging.warning(
+        logger.warning(
             'output_file: %s already exists and will be overwritten on build',
             output_filepath
         )

--- a/sox/file_info.py
+++ b/sox/file_info.py
@@ -1,8 +1,6 @@
 ''' Audio file info computed by soxi.
 '''
-import logging
-
-logger = logging.getLogger('sox')
+from .log import logger
 
 import os
 

--- a/sox/log.py
+++ b/sox/log.py
@@ -1,0 +1,6 @@
+import logging
+
+logger = logging.getLogger('sox')
+console = logging.StreamHandler()
+console.setLevel(logging.WARNING)
+logger.addHandler(console)

--- a/sox/transform.py
+++ b/sox/transform.py
@@ -6,9 +6,7 @@ This module requires that SoX is installed.
 '''
 
 from __future__ import print_function
-import logging
-
-logger = logging.getLogger('sox')
+from .log import logger
 
 import random
 import os

--- a/sox/transform.py
+++ b/sox/transform.py
@@ -7,6 +7,9 @@ This module requires that SoX is installed.
 
 from __future__ import print_function
 import logging
+
+logger = logging.getLogger('sox')
+
 import random
 import os
 
@@ -443,13 +446,13 @@ class Transformer(object):
                 "Stdout: {}\nStderr: {}".format(out, err)
             )
         else:
-            logging.info(
+            logger.info(
                 "Created %s with effects: %s",
                 output_filepath,
                 " ".join(self.effects_log)
             )
             if out is not None:
-                logging.info("[SoX] {}".format(out))
+                logger.info("[SoX] {}".format(out))
 
             if return_output:
                 return status, out, err
@@ -943,7 +946,7 @@ class Transformer(object):
             raise ValueError("decay_time must be a positive number.")
 
         if attack_time > decay_time:
-            logging.warning(
+            logger.warning(
                 "attack_time is larger than decay_time.\n"
                 "For most situations, attack_time should be shorter than "
                 "decay time because the human ear is more sensitive to sudden "
@@ -1780,7 +1783,7 @@ class Transformer(object):
             raise ValueError("decay_time elements must be positive numbers.")
 
         if any([a > d for a, d in zip(attack_time, decay_time)]):
-            logging.warning(
+            logger.warning(
                 "Elements of attack_time are larger than decay_time.\n"
                 "For most situations, attack_time should be shorter than "
                 "decay time because the human ear is more sensitive to sudden "
@@ -2118,7 +2121,7 @@ class Transformer(object):
             raise ValueError("n_semitones must be a positive number")
 
         if n_semitones < -12 or n_semitones > 12:
-            logging.warning(
+            logger.warning(
                 "Using an extreme pitch shift. "
                 "Quality of results will be poor"
             )
@@ -2603,7 +2606,7 @@ class Transformer(object):
             raise ValueError("factor must be a positive number")
 
         if factor < 0.5 or factor > 2:
-            logging.warning(
+            logger.warning(
                 "Using an extreme factor. Quality of results will be poor"
             )
 
@@ -2775,13 +2778,13 @@ class Transformer(object):
             raise ValueError("factor must be a positive number")
 
         if factor < 0.5 or factor > 2:
-            logging.warning(
+            logger.warning(
                 "Using an extreme time stretching factor. "
                 "Quality of results will be poor"
             )
 
         if abs(factor - 1.0) > 0.1:
-            logging.warning(
+            logger.warning(
                 "For this stretch factor, "
                 "the tempo effect has better performance."
             )
@@ -2845,13 +2848,13 @@ class Transformer(object):
             raise ValueError("factor must be a positive number")
 
         if factor < 0.5 or factor > 2:
-            logging.warning(
+            logger.warning(
                 "Using an extreme time stretching factor. "
                 "Quality of results will be poor"
             )
 
         if abs(factor - 1.0) <= 0.1:
-            logging.warning(
+            logger.warning(
                 "For this stretch factor, "
                 "the stretch effect has better performance."
             )

--- a/sox/version.py
+++ b/sox/version.py
@@ -3,4 +3,4 @@
 """Version info"""
 
 short_version = '1.3'
-version = '1.3.1'
+version = '1.3.2'


### PR DESCRIPTION
Closes #51. This is kind of hacky, but should work and should allow callers to configure pysox logging via `logging.getLogger('sox')` on the global `logging` object.