### PR TITLE
Remove grep dependency, parse help string in python

### DIFF
--- a/sox/core.py
+++ b/sox/core.py
@@ -85,11 +85,13 @@ def _get_valid_formats():
     if NO_SOX:
         return []
 
-    shell_output = subprocess.check_output(
-        'sox -h | grep "AUDIO FILE FORMATS"',
-        shell=True
-    )
-    formats = str(shell_output).strip('\n').split(' ')[3:]
+    so = subprocess.check_output('sox -h', shell=True)
+    if type(so) is not str:
+        so = str(so, encoding='UTF-8')
+    so = so.split('\n')
+    idx = [i for i in range(len(so)) if 'AUDIO FILE FORMATS:' in so[i]][0]
+    formats = so[idx].split(' ')[3:]
+
     return formats
 
 

--- a/sox/version.py
+++ b/sox/version.py
@@ -3,4 +3,4 @@
 """Version info"""
 
 short_version = '1.3'
-version = '1.3.2'
+version = '1.3.3'


### PR DESCRIPTION
Calling grep breaks pysox (and subsequently) scaper on windows. This PR addresses this be removing the use of grep altogether and parsing the sox help string directly in python.

Addresses issue #66 in pysox, issue justinsalamon/scaper#25 in scaper