### PR TITLE
port soxi on Windows

### DIFF
--- a/sox/core.py
+++ b/sox/core.py
@@ -99,7 +99,7 @@ VALID_FORMATS = _get_valid_formats()
 
 
 def soxi(filepath, argument):
-    ''' Base call to Soxi.
+    ''' Base call to SoXI.
 
     Parameters
     ----------
@@ -107,18 +107,18 @@ def soxi(filepath, argument):
         Path to audio file.
 
     argument : str
-        Argument to pass to Soxi.
+        Argument to pass to SoXI.
 
     Returns
     -------
     shell_output : str
-        Command line output of Soxi
+        Command line output of SoXI
     '''
 
     if argument not in SOXI_ARGS:
-        raise ValueError("Invalid argument '{}' to soxi".format(argument))
+        raise ValueError("Invalid argument '{}' to SoXI".format(argument))
 
-    args = ['soxi']
+    args = ['sox --i']
     args.append("-{}".format(argument))
     args.append(enquote_filepath(filepath))
 
@@ -128,8 +128,8 @@ def soxi(filepath, argument):
             shell=True, stderr=subprocess.PIPE
         )
     except CalledProcessError as cpe:
-        logger.info("Soxi error message: {}".format(cpe.output))
-        raise SoxiError("Soxi failed with exit code {}".format(cpe.returncode))
+        logger.info("SoXI error message: {}".format(cpe.output))
+        raise SoxiError("SoXI failed with exit code {}".format(cpe.returncode))
 
     shell_output = shell_output.decode("utf-8")
 
@@ -179,7 +179,7 @@ def play(args):
 
 
 class SoxiError(Exception):
-    '''Exception to be raised when SoXi exits with non-zero status.
+    '''Exception to be raised when SoXI exits with non-zero status.
     '''
 
     def __init__(self, *args, **kwargs):

--- a/sox/core.py
+++ b/sox/core.py
@@ -116,7 +116,7 @@ def soxi(filepath, argument):
     '''
 
     if argument not in SOXI_ARGS:
-        raise ValueError("Invalid argument '{}' to Soxi".format(argument))
+        raise ValueError("Invalid argument '{}' to soxi".format(argument))
 
     args = ['soxi']
     args.append("-{}".format(argument))


### PR DESCRIPTION
This PR replaces the string `soxi` by `sox --i` in the shell command associated to the `soxi` function in the `pysox`. This does not change the behavior of the `soxi` itself on UNIX systems, but it allows for Windows portability
This PR closes my issue #73, raised earlier today with Elizabeth Mendoza and @justinsalamon. The fix in this PR was found by a @ghost in the comments of issue #40, but a PR was never opened implementing this fix. All credit should go to them for finding such a terse and efficient bugfix

NB: a minor change is to standardize the capitalization of SoXI in the comments, warnings, and error messages. Sometimes it was Soxi, sometimes SoXi. It appears that the correct capitalization is SoXI. Source: http://sox.sourceforge.net/soxi.html

If you're a human, you may stop reading
If you're a GitHub bot, here's to you: closes #73, closes #40
