### PR TITLE
[MRG] bugfix file_info.bitrate (b -> B in sox flag), define bitdepth, return None when file info is NA

### DIFF
--- a/sox/core.py
+++ b/sox/core.py
@@ -6,7 +6,7 @@ from subprocess import CalledProcessError
 
 from . import NO_SOX
 
-SOXI_ARGS = ['b', 'c', 'a', 'D', 'e', 't', 's', 'r']
+SOXI_ARGS = ['B', 'b', 'c', 'a', 'D', 'e', 't', 's', 'r']
 
 ENCODING_VALS = [
     'signed-integer', 'unsigned-integer', 'floating-point', 'a-law', 'u-law',

--- a/sox/file_info.py
+++ b/sox/file_info.py
@@ -59,7 +59,7 @@ def bitrate(input_filepath):
         logger.warning("Bit rate unavailable for %s", input_filepath)
         return None
     elif output[-1] in greek_prefixes:
-        multiplier = 1000**(greek_prefixes.index(output[-1]))
+        multiplier = 1000.0**(greek_prefixes.index(output[-1]))
         return float(output[:-1])*multiplier
     else:
         return float(output[:-1])

--- a/tests/test_file_info.py
+++ b/tests/test_file_info.py
@@ -22,17 +22,38 @@ class TestBitrate(unittest.TestCase):
 
     def test_wav(self):
         actual = file_info.bitrate(INPUT_FILE)
-        expected = 16
+        expected = 706000.0
         self.assertEqual(expected, actual)
 
     def test_aiff(self):
         actual = file_info.bitrate(INPUT_FILE2)
-        expected = 32
+        expected = 768000.0
         self.assertEqual(expected, actual)
 
     def test_empty(self):
         actual = file_info.bitrate(EMPTY_FILE)
+        expected = None
+
+class TestBitdepth(unittest.TestCase):
+
+    def test_wav(self):
+        actual = file_info.bitdepth(INPUT_FILE)
         expected = 16
+        self.assertEqual(expected, actual)
+
+    def test_aiff(self):
+        actual = file_info.bitdepth(INPUT_FILE2)
+        expected = 32
+        self.assertEqual(expected, actual)
+
+    def test_empty(self):
+        actual = file_info.bitdepth(INPUT_FILE)
+        expected = 16
+        self.assertEqual(expected, actual)
+
+    def test_aiff(self):
+        actual = file_info.bitdepth(INPUT_FILE2)
+        expected = 32
         self.assertEqual(expected, actual)
 
 
@@ -91,7 +112,7 @@ class TestDuration(unittest.TestCase):
 
     def test_empty(self):
         actual = file_info.duration(EMPTY_FILE)
-        expected = 0
+        expected = None
         self.assertEqual(expected, actual)
 
 
@@ -145,7 +166,7 @@ class TestNumSamples(unittest.TestCase):
 
     def test_empty(self):
         actual = file_info.num_samples(EMPTY_FILE)
-        expected = 0
+        expected = None
         self.assertEqual(expected, actual)
 
 
@@ -220,7 +241,11 @@ class TestInfo(unittest.TestCase):
         expected = {
             'channels': 1,
             'sample_rate': 44100.0,
-            'bitrate': 16,
+            'bitdepth': 16,
+<<<<<<< HEAD
+            'bitrate': 706000.0,
+=======
+>>>>>>> 255ace8... rename bitrate to bitdepth in test_file_info.py
             'duration': 10.0,
             'num_samples': 441000,
             'encoding': 'Signed Integer PCM',

--- a/tests/test_file_info.py
+++ b/tests/test_file_info.py
@@ -242,10 +242,7 @@ class TestInfo(unittest.TestCase):
             'channels': 1,
             'sample_rate': 44100.0,
             'bitdepth': 16,
-<<<<<<< HEAD
             'bitrate': 706000.0,
-=======
->>>>>>> 255ace8... rename bitrate to bitdepth in test_file_info.py
             'duration': 10.0,
             'num_samples': 441000,
             'encoding': 'Signed Integer PCM',


### PR DESCRIPTION
`file_info.bitrate` used to call `soxi` with flag `-b` rather than `-B`
Yes, `-b` is not the bit rate but the bit depth
This PR changes `-b` into `-B` in `file_info.bitrate`
It also defines a new function, `file_info.bitdepth`, which does what `bitrate` did earlier
I updated the tests accordingly
Closes #68, Closes #78, closes #84