### PR TITLE
update license (MIT -> BSD-3-Clause)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Python wrapper around sox. [Read the Docs here](http://pysox.readthedocs.org).
 
 [![PyPI version](https://badge.fury.io/py/sox.svg)](https://badge.fury.io/py/sox)
 [![Documentation Status](https://readthedocs.org/projects/resampy/badge/?version=latest)](http://pysox.readthedocs.io/en/latest/?badge=latest)
-[![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/rabitt/pysox/master/LICENSE.md)
+[![GitHub license](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://raw.githubusercontent.com/rabitt/pysox/master/LICENSE.md)
 [![PyPI](https://img.shields.io/pypi/pyversions/Django.svg?maxAge=2592000)]()
 
 [![Build Status](https://travis-ci.org/rabitt/pysox.svg?branch=master)](https://travis-ci.org/rabitt/pysox)

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ if __name__ == "__main__":
         package_data={'sox': []},
         long_description="""Python wrapper around SoX.""",
         keywords='audio effects SoX',
-        license='MIT',
+        license='BSD-3-Clause',
         install_requires=[
         ],
         extras_require={


### PR DESCRIPTION
BSD-3-Clause is the official SPDX identifier. Added to `setup.py`
Closes #52 