### PR TITLE
Fix typo in docstrings [ci skip]

### DIFF
--- a/sox/transform.py
+++ b/sox/transform.py
@@ -2682,7 +2682,7 @@ class Transformer(object):
         Returns
         -------
         power_spectrum : list
-            List of frequency (Hz), amplitdue pairs.
+            List of frequency (Hz), amplitude pairs.
 
         See Also
         --------
@@ -2725,7 +2725,7 @@ class Transformer(object):
         Returns
         -------
         stats_dict : dict
-            List of frequency (Hz), amplitdue pairs.
+            List of frequency (Hz), amplitude pairs.
 
         See Also
         --------


### PR DESCRIPTION
Addresses a comment in issue #45
https://github.com/rabitt/pysox/issues/45#issuecomment-290924367
Update `transform.power_spectrum` and `transform.stats` docstrings