### PR TITLE
Updating __init__.py to remove stderr warnings in external unit tests

### DIFF
--- a/sox/__init__.py
+++ b/sox/__init__.py
@@ -5,7 +5,8 @@ import os
 
 # Check that SoX is installed and callable
 NO_SOX = False
-if not len(os.popen('sox -h').readlines()):
+stream_handler = os.popen('sox -h')
+if not len(stream_handler.readlines()):
     logger.warning("""SoX could not be found!
 
     If you do not have SoX, proceed here:
@@ -15,6 +16,7 @@ if not len(os.popen('sox -h').readlines()):
     path variables.
     """)
     NO_SOX = True
+stream_handler.close()
 
 from . import file_info
 from .combine import Combiner


### PR DESCRIPTION
When running unit tests on modules that import this library, I was running into some stderr warnings that looked like this:
```
/usr/local/Cellar/python/3.6.5/Frameworks/Python.framework/Versions/3.6/lib/python3.6/subprocess.py:766: ResourceWarning: subprocess 49364 is still running
  ResourceWarning, source=self)
/virtualenvs/36/lib/python3.6/site-packages/sox/__init__.py:8: ResourceWarning: unclosed file <_io.TextIOWrapper name=3 encoding='UTF-8'>
  if not len(os.popen('sox -h').readlines()):
```

This PR removes those stderr warnings by closing the stream handler after use.

Note that I've never seen the above warnings when running code that imports sox. It seems to be related to the way the `unittest` module quickly initializes and disposes of imported modules.

I validated that the existing unit tests in the `sox` module passed after this change.

[added by @lostanlen: closes #96]