### PR TITLE
Updated build API for 1.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ y = np.sin(2 * np.pi * 440.0 * np.arange(sample_rate * 1.0) / sample_rate)
 tfm = sox.Transformer()
 # shift the pitch up by 2 semitones
 tfm.pitch(2)
-# compute transformation in-memory
+# transform an in-memory array and return an array
 y_out = tfm.build_array(input_array=y, sample_rate_in=sample_rate)
 # instead, save output to a file
 tfm.build_file(

--- a/README.md
+++ b/README.md
@@ -56,10 +56,10 @@ python setup.py install
 # Tests
 
 If you have a different version of SoX installed, it's recommended that you run
-the tests locally to make sure everything behaves as expected:
+the tests locally to make sure everything behaves as expected, by simply running:
 
 ```
-pytest tests/
+pytest
 ```
 
 # Examples
@@ -75,10 +75,12 @@ tfm.compand()
 # apply a fade in and fade out
 tfm.fade(fade_in_len=1.0, fade_out_len=0.5)
 # create an output file.
+tfm.build_file('path/to/input_audio.wav', 'path/to/output/audio.aiff')
+# or equivalently using the legacy API
 tfm.build('path/to/input_audio.wav', 'path/to/output/audio.aiff')
 # get the output in-memory as a numpy array
 # by default the sample rate will be the same as the input file
-status, audio_out, err = tfm.build(input_filepath='path/to/input_audio.wav')
+array_out = tfm.build_array(input_filepath='path/to/input_audio.wav')
 # see the applied effects
 tfm.effects_log
 > ['trim', 'compand', 'fade']
@@ -98,15 +100,15 @@ tfm = sox.Transformer()
 # shift the pitch up by 2 semitones
 tfm.pitch(2)
 # compute transformation in-memory
-status, y_out, err = tfm.build(input_array=y, sample_rate_in=sample_rate)
+y_out = tfm.build_array(input_array=y, sample_rate_in=sample_rate)
 # instead, save output to a file
-tfm.build(
+tfm.build_file(
     input_array=y, sample_rate_in=sample_rate,
     output_filepath='path/to/output.wav'
 )
 # create an output file with a different sample rate
 tfm.set_output_format(rate=8000)
-tfm.build(
+tfm.build_file(
     input_array=y, sample_rate_in=sample_rate,
     output_filepath='path/to/output_8k.wav'
 )

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,7 +15,6 @@
 
 import sys
 import os
-import shlex
 import imp
 
 # If extensions (or modules to document with autodoc) are in another directory,

--- a/docs/example.rst
+++ b/docs/example.rst
@@ -9,7 +9,7 @@ Transform audio files
     :linenos:
 
     import sox
-    # create trasnformer
+    # create transformer
     tfm = sox.Transformer()
     # trim the audio between 5 and 10.5 seconds.
     tfm.trim(5, 10.5)
@@ -18,10 +18,12 @@ Transform audio files
     # apply a fade in and fade out
     tfm.fade(fade_in_len=1.0, fade_out_len=0.5)
     # create an output file.
+    tfm.build_file('path/to/input_audio.wav', 'path/to/output/audio.aiff')
+    # or equivalently using the legacy API
     tfm.build('path/to/input_audio.wav', 'path/to/output/audio.aiff')
     # get the output in-memory as a numpy array
     # by default the sample rate will be the same as the input file
-    status, audio_out, err = tfm.build(input_filepath='path/to/input_audio.wav')
+    array_out = tfm.build_array(input_filepath='path/to/input_audio.wav')
     # see the applied effects
     tfm.effects_log
     > ['trim', 'compand', 'fade']
@@ -42,15 +44,15 @@ Transform in-memory arrays
     # shift the pitch up by 2 semitones
     tfm.pitch(2)
     # compute transformation in-memory
-    status, y_out, err = tfm.build(input_array=y, sample_rate_in=sample_rate)
+    y_out = tfm.build_array(input_array=y, sample_rate_in=sample_rate)
     # instead, save output to a file
-    tfm.build(
+    tfm.build_file(
         input_array=y, sample_rate_in=sample_rate,
         output_filepath='path/to/output.wav'
     )
     # create an output file with a different sample rate
     tfm.set_output_format(rate=8000)
-    tfm.build(
+    tfm.build_file(
         input_array=y, sample_rate_in=sample_rate,
         output_filepath='path/to/output_8k.wav'
     )

--- a/docs/example.rst
+++ b/docs/example.rst
@@ -43,7 +43,7 @@ Transform in-memory arrays
     tfm = sox.Transformer()
     # shift the pitch up by 2 semitones
     tfm.pitch(2)
-    # compute transformation in-memory
+    # transform an in-memory array and return an array
     y_out = tfm.build_array(input_array=y, sample_rate_in=sample_rate)
     # instead, save output to a file
     tfm.build_file(

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,10 +6,10 @@
 Welcome to pysox's documentation!
 =================================
 
-pysox is a Python wrapper around the amazing `SoX <(http://sox.sourceforge.net/)>`_ command line tool.
+pysox is a Python wrapper around the amazing `SoX <http://sox.sourceforge.net/>`_ command line tool.
 
 .. code-block:: python
-
+    # within python
     import sox
 
 
@@ -21,21 +21,22 @@ On Linux
 .. code-block:: shell
 
     # optional - if you want support for mp3, flac and ogg files
-    apt-get install libsox-fmt-all
+    $ apt-get install libsox-fmt-all
     # install the sox command line tool
-    apt-get install sox
+    $ apt-get install sox
     # install pysox
-    pip install sox
+    $ pip install sox
 
-On Mac
+On Mac with `Homebrew <https://brew.sh/>`_
 
 .. code-block:: shell
+
     # optional - if you want support for mp3, flac and ogg files
-    brew install sox --with-lame --with-flac --with-libvorbis
+    $ brew install sox --with-lame --with-flac --with-libvorbis
     # install the sox command line tool
-    brew install sox
+    $ brew install sox
     # install pysox
-    pip install sox
+    $ pip install sox
 
 
 Examples
@@ -72,3 +73,20 @@ Indices and tables
 * :ref:`search`
 
 
+pysox vs sox
+============
+The original command line tool is called `SoX <http://sox.sourceforge.net/>`_
+
+This project (the `github repository <http://github.com/rabitt/pysox>`_) is called pysox
+
+The library within python is called `sox`. It can be installed via:
+
+.. code-block:: shell
+
+    $ pip install sox
+
+and imported within Python as
+
+.. code-block:: python
+
+    import sox

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,6 +6,38 @@
 Welcome to pysox's documentation!
 =================================
 
+pysox is a Python wrapper around the amazing `SoX <(http://sox.sourceforge.net/)>`_ command line tool.
+
+.. code-block:: python
+
+    import sox
+
+
+Installation
+------------
+
+On Linux
+
+.. code-block:: shell
+
+    # optional - if you want support for mp3, flac and ogg files
+    apt-get install libsox-fmt-all
+    # install the sox command line tool
+    apt-get install sox
+    # install pysox
+    pip install sox
+
+On Mac
+
+.. code-block:: shell
+    # optional - if you want support for mp3, flac and ogg files
+    brew install sox --with-lame --with-flac --with-libvorbis
+    # install the sox command line tool
+    brew install sox
+    # install pysox
+    pip install sox
+
+
 Examples
 --------
 .. toctree::

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,4 @@
+[metadata]
+description-file = README.md
 [bdist_wheel]
 universal = 1

--- a/sox/combine.py
+++ b/sox/combine.py
@@ -79,7 +79,8 @@ class Combiner(Transformer):
         _validate_volumes(input_volumes)
 
         input_format_list = _build_input_format_list(
-            input_filepath_list, input_volumes, self.input_format
+            input_filepath_list, input_volumes,
+            self.input_format
         )
 
         try:
@@ -94,7 +95,7 @@ class Combiner(Transformer):
         input_args = _build_input_args(input_filepath_list, input_format_list)
         args.extend(input_args)
 
-        args.extend(self.output_format)
+        args.extend(self._output_format_args(self.output_format))
         args.append(output_filepath)
         args.extend(self.effects)
 

--- a/sox/transform.py
+++ b/sox/transform.py
@@ -43,7 +43,11 @@ class Transformer(object):
     set_globals
         Overwrite the default global arguments.
     build
-        Execute the current chain of commands and write output file.
+        Execute the current chain of commands to create an output file.
+    build_file
+        Alias of build.
+    build_array
+        Execute the current chain of commands to create an output array.
 
     '''
 
@@ -63,8 +67,8 @@ class Transformer(object):
             Global arguments that will be passed to SoX.
 
         '''
-        self.input_format = []
-        self.output_format = []
+        self.input_format = {}
+        self.output_format = {}
 
         self.effects = []
         self.effects_log = []
@@ -141,11 +145,16 @@ class Transformer(object):
         self.globals = global_args
         return self
 
-
-    def _input_format_args(self, file_type, rate, bits, channels, encoding,
-                           ignore_length):
-        '''Private helper function for set_input_format
+    def _validate_input_format(self, input_format):
+        '''Private helper function for validating input formats
         '''
+        file_type = input_format.get('file_type')
+        rate = input_format.get('rate')
+        bits = input_format.get('bits')
+        channels = input_format.get('channels')
+        encoding = input_format.get('encoding')
+        ignore_length = input_format.get('ignore_length', False)
+
         if file_type not in VALID_FORMATS + [None]:
             raise ValueError(
                 'Invalid file_type. Must be one of {}'.format(VALID_FORMATS)
@@ -178,27 +187,39 @@ class Transformer(object):
         if not isinstance(ignore_length, bool):
             raise ValueError('ignore_length must be a boolean')
 
-        input_format = []
+    def _input_format_args(self, input_format):
+        '''Private helper function for set_input_format
+        '''
+        self._validate_input_format(input_format)
+
+        file_type = input_format.get('file_type')
+        rate = input_format.get('rate')
+        bits = input_format.get('bits')
+        channels = input_format.get('channels')
+        encoding = input_format.get('encoding')
+        ignore_length = input_format.get('ignore_length', False)
+
+        input_format_args = []
 
         if file_type is not None:
-            input_format.extend(['-t', '{}'.format(file_type)])
+            input_format_args.extend(['-t', '{}'.format(file_type)])
 
         if rate is not None:
-            input_format.extend(['-r', '{:f}'.format(rate)])
+            input_format_args.extend(['-r', '{:f}'.format(rate)])
 
         if bits is not None:
-            input_format.extend(['-b', '{}'.format(bits)])
+            input_format_args.extend(['-b', '{}'.format(bits)])
 
         if channels is not None:
-            input_format.extend(['-c', '{}'.format(channels)])
+            input_format_args.extend(['-c', '{}'.format(channels)])
 
         if encoding is not None:
-            input_format.extend(['-e', '{}'.format(encoding)])
+            input_format_args.extend(['-e', '{}'.format(encoding)])
 
         if ignore_length:
-            input_format.append('--ignore-length')
+            input_format_args.append('--ignore-length')
 
-        return input_format
+        return input_format_args
 
     def set_input_format(self, file_type=None, rate=None, bits=None,
                          channels=None, encoding=None, ignore_length=False):
@@ -263,21 +284,29 @@ class Transformer(object):
             If True, overrides an (incorrect) audio length given in an audio
             file’s header. If this option is given then SoX will keep reading
             audio until it reaches the end of the input file.
-
-        Returns
-        -------
-        input_format : list
-            List of arguments that determine the input format, passed to sox.
-
         '''
-        self.input_format = self._input_format_args(
-            file_type, rate, bits, channels, encoding, ignore_length
-        )
+        input_format = {
+            'file_type': file_type,
+            'rate': rate,
+            'bits': bits,
+            'channels': channels,
+            'encoding': encoding,
+            'ignore_length': ignore_length
+        }
+        self._validate_input_format(input_format)
+        self.input_format = input_format
 
-    def _output_format_args(self, file_type, rate, bits, channels, encoding,
-                            comments, append_comments):
-        '''Private helper function for set_output_format
+    def _validate_output_format(self, output_format):
+        '''Private helper function for validating input formats
         '''
+        file_type = output_format.get('file_type')
+        rate = output_format.get('rate')
+        bits = output_format.get('bits')
+        channels = output_format.get('channels')
+        encoding = output_format.get('encoding')
+        comments = output_format.get('comments')
+        append_comments = output_format.get('append_comments', True)
+
         if file_type not in VALID_FORMATS + [None]:
             raise ValueError(
                 'Invalid file_type. Must be one of {}'.format(VALID_FORMATS)
@@ -312,30 +341,43 @@ class Transformer(object):
         if not isinstance(append_comments, bool):
             raise ValueError('append_comments must be a boolean')
 
-        output_format = []
+    def _output_format_args(self, output_format):
+        '''Private helper function for set_output_format
+        '''
+        self._validate_output_format(output_format)
+
+        file_type = output_format.get('file_type')
+        rate = output_format.get('rate')
+        bits = output_format.get('bits')
+        channels = output_format.get('channels')
+        encoding = output_format.get('encoding')
+        comments = output_format.get('comments')
+        append_comments = output_format.get('append_comments', True)
+
+        output_format_args = []
 
         if file_type is not None:
-            output_format.extend(['-t', '{}'.format(file_type)])
+            output_format_args.extend(['-t', '{}'.format(file_type)])
 
         if rate is not None:
-            output_format.extend(['-r', '{:f}'.format(rate)])
+            output_format_args.extend(['-r', '{:f}'.format(rate)])
 
         if bits is not None:
-            output_format.extend(['-b', '{}'.format(bits)])
+            output_format_args.extend(['-b', '{}'.format(bits)])
 
         if channels is not None:
-            output_format.extend(['-c', '{}'.format(channels)])
+            output_format_args.extend(['-c', '{}'.format(channels)])
 
         if encoding is not None:
-            output_format.extend(['-e', '{}'.format(encoding)])
+            output_format_args.extend(['-e', '{}'.format(encoding)])
 
         if comments is not None:
             if append_comments:
-                output_format.extend(['--add-comment', comments])
+                output_format_args.extend(['--add-comment', comments])
             else:
-                output_format.extend(['--comment', comments])
+                output_format_args.extend(['--comment', comments])
 
-        return output_format
+        return output_format_args
 
     def set_output_format(self, file_type=None, rate=None, bits=None,
                           channels=None, encoding=None, comments=None,
@@ -402,18 +444,18 @@ class Transformer(object):
         append_comments : bool, default=True
             If True, comment strings are appended to SoX's default comments. If
             False, the supplied comment replaces the existing comment.
-
-        Returns
-        -------
-        output_format : list
-            List of arguments that determine the output format, passed to sox.
-
-
         '''
-        self.output_format = self._output_format_args(
-            file_type, rate, bits, channels, encoding, comments,
-            append_comments
-        )
+        output_format = {
+            'file_type': file_type,
+            'rate': rate,
+            'bits': bits,
+            'channels': channels,
+            'encoding': encoding,
+            'comments': comments,
+            'append_comments': append_comments
+        }
+        self._validate_output_format(output_format)
+        self.output_format = output_format
 
     def clear_effects(self):
         '''Remove all effects processes.
@@ -422,27 +464,80 @@ class Transformer(object):
         self.effects_log = list()
         return self
 
-    def build(self, input_filepath=None, output_filepath=None,
-              input_array=None, sample_rate_in=None,
-              extra_args=None, return_output=False):
-        '''Builds the output file or output numpy array by executing the
-        current set of commands. This function returns either the status
-        of the command (when output_filepath is specified and return_output
-        is False), or it returns a triple of (status, out, err) when
-        output_filepath is None or return_output is True.
+    def _parse_inputs(self, input_filepath, input_array, sample_rate_in):
+        '''Private helper function for parsing inputs to build and build_array
 
         Parameters
         ----------
         input_filepath : str or None
             Either path to input audio file or None.
-        output_filepath : str or None
+        input_array : np.ndarray or None
+            A np.ndarray of an waveform with shape (n_samples, n_channels)
+            or None
+        sample_rate_in : int or None
+            Sample rate of input_array or None
+
+        Returns
+        -------
+        input_format : dict
+            Input format dictionary
+        input_filepath : str
+            Formatted input filepath.
+        '''
+        if input_filepath is not None and input_array is not None:
+            raise ValueError(
+                "Only one of input_filepath and input_array may be specified"
+            )
+        # set input parameters
+        if input_filepath is not None:
+            file_info.validate_input_file(input_filepath)
+            input_format = self.input_format
+            if input_format.get('channels') is None:
+                input_format['channels'] = file_info.channels(input_filepath)
+        elif input_array is not None:
+            if not isinstance(input_array, np.ndarray):
+                raise TypeError("input_array must be a numpy array or None")
+            if sample_rate_in is None:
+                raise ValueError(
+                    "sample_rate_in must be specified for array inputs"
+                )
+            input_filepath = '-'
+            input_format = {
+                'file_type': ENCODINGS_MAPPING[input_array.dtype.type],
+                'rate': sample_rate_in,
+                'bits': None,
+                'channels': (
+                    input_array.shape[-1] if len(input_array.shape) > 1 else 1
+                ),
+                'encoding': None,
+                'ignore_length': False
+            }
+        else:
+            raise ValueError(
+                "One of input_filepath or input_array must be specified"
+            )
+        return input_format, input_filepath
+
+    def build(self, input_filepath=None, output_filepath=None,
+              input_array=None, sample_rate_in=None,
+              extra_args=None, return_output=False):
+        '''Given an input file or array, creates an output_file on disk by
+        executing the current set of commands. This function returns True on
+        success. If return_output is True, this function returns a triple of
+        (status, out, err), giving the success state, along with stdout and
+        stderr returned by sox.
+
+        Parameters
+        ----------
+        input_filepath : str or None
+            Either path to input audio file or None for array input.
+        output_filepath : str
             Path to desired output file. If a file already exists at
             the given path, the file will be overwritten.
-            If None, the output will be returned as an np.ndarray.
             If '-n', no file is created.
         input_array : np.ndarray or None
-            A np.ndarray of an waveform with shape (n_samples, n_channels).
-            If this argument is passed, sample_rate_in must also be provided.
+            An np.ndarray of an waveform with shape (n_samples, n_channels).
+            sample_rate_in must also be provided.
             If None, input_filepath must be specified.
         sample_rate_in : int
             Sample rate of input_array.
@@ -461,19 +556,15 @@ class Transformer(object):
         -------
         status : bool
             True on success.
-        out : str, np.ndarray, or None
-            If output_filepath is None returns the output audio as a np.ndarray
-            If output_filepath is not None and return_output is True, returns
-            the stdout produced by sox.
-            Otherwise, this output is not returned.
-        err : str, or None
-            If output_filepath is None or return_output is True, returns the
-            stderr as a string.
-            Otherwise, this output is not returned.
+        out : str (optional)
+            This is not returned unless return_output is True.
+            When returned, captures the stdout produced by sox.
+        err : str (optional)
+            This is not returned unless return_output is True.
+            When returned, captures the stderr produced by sox.
 
         Examples
         --------
-
         >>> import numpy as np
         >>> import sox
         >>> tfm = sox.Transformer()
@@ -491,10 +582,6 @@ class Transformer(object):
                 output_filepath='path/to/output.mp3'
             )
 
-        file in, array out
-
-        >>> status, array_out, err = tfm.build(input_filepath='path/to/input.wav')
-
         array in, file out
 
         >>> status = tfm.build(
@@ -502,100 +589,26 @@ class Transformer(object):
                 output_filepath='path/to/output.mp3'
             )
 
-        array in, array out
-
-        >>> status, array_out, err = tfm.build(input_array=y, sample_rate_in=sample_rate)
-
         '''
-        if input_filepath is not None and input_array is not None:
-            raise ValueError(
-                "Only one of input_filepath and input_array may be specified"
-            )
+        input_format, input_filepath = self._parse_inputs(
+            input_filepath, input_array, sample_rate_in
+        )
 
-        # set input parameters
-        input_format = self.input_format
-        encoding = None
-        if input_filepath is not None:
-            file_info.validate_input_file(input_filepath)
-            channels_in = file_info.channels(input_filepath)
-        elif input_array is not None:
-            if not isinstance(input_array, np.ndarray):
-                raise TypeError("input_array must be a numpy array or None")
-            if sample_rate_in is None:
-                raise ValueError(
-                    "sample_rate_in must be specified if input_array is specified"
-                )
-            input_filepath = '-'
-            channels_in = (
-                input_array.shape[-1] if len(input_array.shape) > 1 else 1
-            )
-            encoding = input_array.dtype.type
-            input_format = self._input_format_args(
-                ENCODINGS_MAPPING[encoding], sample_rate_in, None,
-                channels_in, None, False
-            )
-        else:
-            raise ValueError(
-                "One of input_filepath or input_array must be specified"
-            )
+        if output_filepath is None:
+            raise ValueError("output_filepath is not specified!")
 
         # set output parameters
-        output_format = self.output_format
-        if output_filepath is not None:
-            if input_filepath == output_filepath:
-                raise ValueError(
-                    "input_filepath must be different from output_filepath."
-                )
-            file_info.validate_output_file(output_filepath)
-            array_output = False
-        else:
-            ignored_commands = ['rate', 'channels', 'convert']
-            if len(list(set(ignored_commands) & set(self.effects_log))) > 0:
-                logger.warning(
-                    "When outputting to an array, rate, channels and convert" +
-                    " effects may be ignored. Use set_output_format() to " +
-                    "specify output formats."
-                )
-
-            output_filepath = '-'
-            channels_out = channels_in
-            encoding_out = (np.int16 if encoding is None else encoding)
-            n_bits = np.dtype(encoding_out).itemsize * 8
-            if output_format == []:
-                output_format = self._output_format_args(
-                    'raw', sample_rate_in, n_bits,
-                    channels_out, None, None, True
-                )
-            else:
-                channels_idx = [
-                    i for i, f in enumerate(output_format) if f == '-c'
-                ]
-                if len(channels_idx) == 1:
-                    channels_out = int(output_format[channels_idx[0] + 1])
-
-                bits_idx = [
-                    i for i, f in enumerate(output_format) if f == '-b'
-                ]
-                if len(bits_idx) == 1:
-                    n_bits = int(output_format[bits_idx[0] + 1])
-                    if n_bits == 8:
-                        encoding_out = np.int8
-                    elif n_bits == 16:
-                        encoding_out = np.int16
-                    elif n_bits == 32:
-                        encoding_out = np.float32
-                    elif n_bits == 64:
-                        encoding_out = np.float64
-                    else:
-                        raise ValueError("invalid n_bits {}".format(n_bits))
-
-            array_output = True
+        if input_filepath == output_filepath:
+            raise ValueError(
+                "input_filepath must be different from output_filepath."
+            )
+        file_info.validate_output_file(output_filepath)
 
         args = []
         args.extend(self.globals)
-        args.extend(input_format)
+        args.extend(self._input_format_args(input_format))
         args.append(input_filepath)
-        args.extend(output_format)
+        args.extend(self._output_format_args(self.output_format))
         args.append(output_filepath)
         args.extend(self.effects)
 
@@ -604,36 +617,249 @@ class Transformer(object):
                 raise ValueError("extra_args must be a list.")
             args.extend(extra_args)
 
-        decode_out_with_utf = not array_output
-        status, out, err = sox(args, input_array, decode_out_with_utf)
+        status, out, err = sox(args, input_array, True)
         if status != 0:
             raise SoxError(
                 "Stdout: {}\nStderr: {}".format(out, err)
             )
 
-        if array_output:
-            out = np.frombuffer(out, dtype=encoding_out)
-            if channels_out > 1:
-                out = out.reshape(
-                    (channels_out, int(len(out) / channels_out)), order='F'
-                ).T
-            logger.info(
-                "Created array with effects: %s",
-                " ".join(self.effects_log)
-            )
-        else:
-            logger.info(
-                "Created %s with effects: %s",
-                output_filepath,
-                " ".join(self.effects_log)
+        logger.info(
+            "Created %s with effects: %s",
+            output_filepath,
+            " ".join(self.effects_log)
+        )
+
+        if return_output:
+            return status, out, err
+
+        return True
+
+    def build_file(self, input_filepath=None, output_filepath=None,
+                   input_array=None, sample_rate_in=None,
+                   extra_args=None, return_output=False):
+        '''An alias for build.
+        Given an input file or array, creates an output_file on disk by
+        executing the current set of commands. This function returns True on
+        success. If return_output is True, this function returns a triple of
+        (status, out, err), giving the success state, along with stdout and
+        stderr returned by sox.
+
+        Parameters
+        ----------
+        input_filepath : str or None
+            Either path to input audio file or None for array input.
+        output_filepath : str
+            Path to desired output file. If a file already exists at
+            the given path, the file will be overwritten.
+            If '-n', no file is created.
+        input_array : np.ndarray or None
+            An np.ndarray of an waveform with shape (n_samples, n_channels).
+            sample_rate_in must also be provided.
+            If None, input_filepath must be specified.
+        sample_rate_in : int
+            Sample rate of input_array.
+            This argument is ignored if input_array is None.
+        extra_args : list or None, default=None
+            If a list is given, these additional arguments are passed to SoX
+            at the end of the list of effects.
+            Don't use this argument unless you know exactly what you're doing!
+        return_output : bool, default=False
+            If True, returns the status and information sent to stderr and
+            stdout as a tuple (status, stdout, stderr).
+            If output_filepath is None, return_output=True by default.
+            If False, returns True on success.
+
+        Returns
+        -------
+        status : bool
+            True on success.
+        out : str (optional)
+            This is not returned unless return_output is True.
+            When returned, captures the stdout produced by sox.
+        err : str (optional)
+            This is not returned unless return_output is True.
+            When returned, captures the stderr produced by sox.
+
+        Examples
+        --------
+        >>> import numpy as np
+        >>> import sox
+        >>> tfm = sox.Transformer()
+        >>> sample_rate = 44100
+        >>> y = np.sin(2 * np.pi * 440.0 * np.arange(sample_rate * 1.0) / sample_rate)
+
+        file in, file out - basic usage
+
+        >>> status = tfm.build('path/to/input.wav', 'path/to/output.mp3')
+
+        file in, file out - equivalent usage
+
+        >>> status = tfm.build(
+                input_filepath='path/to/input.wav',
+                output_filepath='path/to/output.mp3'
             )
 
-        if return_output or array_output:
-            return status, out, err
+        array in, file out
+
+        >>> status = tfm.build(
+                input_array=y, sample_rate_in=sample_rate,
+                output_filepath='path/to/output.mp3'
+            )
+
+        '''
+        return self.build(
+            input_filepath, output_filepath, input_array, sample_rate_in,
+            extra_args, return_output
+        )
+
+    def build_array(self, input_filepath=None, input_array=None,
+                    sample_rate_in=None, extra_args=None):
+        '''Given an input file or array, returns the ouput as a numpy array
+        by executing the current set of commands. By default the array will
+        have the same sample rate as the input file unless otherwise specified
+        using set_output_format. Functions such as rate, channels and convert
+        will be ignored!
+
+        Parameters
+        ----------
+        input_filepath : str or None
+            Either path to input audio file or None.
+        input_array : np.ndarray or None
+            A np.ndarray of an waveform with shape (n_samples, n_channels).
+            If this argument is passed, sample_rate_in must also be provided.
+            If None, input_filepath must be specified.
+        sample_rate_in : int
+            Sample rate of input_array.
+            This argument is ignored if input_array is None.
+        extra_args : list or None, default=None
+            If a list is given, these additional arguments are passed to SoX
+            at the end of the list of effects.
+            Don't use this argument unless you know exactly what you're doing!
+
+        Returns
+        -------
+        output_array : np.ndarray
+            Output audio as a numpy array
+
+        Examples
+        --------
+
+        >>> import numpy as np
+        >>> import sox
+        >>> tfm = sox.Transformer()
+        >>> sample_rate = 44100
+        >>> y = np.sin(2 * np.pi * 440.0 * np.arange(sample_rate * 1.0) / sample_rate)
+
+        file in, array out
+
+        >>> output_array = tfm.build(input_filepath='path/to/input.wav')
+
+        array in, array out
+
+        >>> output_array = tfm.build(input_array=y, sample_rate_in=sample_rate)
+
+        specifying the output sample rate
+
+        >>> tfm.set_output_format(rate=8000)
+        >>> output_array = tfm.build(input_array=y, sample_rate_in=sample_rate)
+
+        if an effect changes the number of channels, you must explicitly
+        specify the number of output channels
+
+        >>> tfm.remix(remix_dictionary={1: [1], 2: [1], 3: [1]})
+        >>> tfm.set_output_format(channels=3)
+        >>> output_array = tfm.build(input_array=y, sample_rate_in=sample_rate)
+
+
+        '''
+        input_format, input_filepath = self._parse_inputs(
+            input_filepath, input_array, sample_rate_in
+        )
+
+        # check if any of the below commands are part of the effects chain
+        ignored_commands = ['rate', 'channels', 'convert']
+        if set(ignored_commands) & set(self.effects_log):
+            logger.warning(
+                "When outputting to an array, rate, channels and convert " +
+                "effects may be ignored. Use set_output_format() to " +
+                "specify output formats."
+            )
+
+        output_filepath = '-'
+
+        if input_format.get('file_type') is None:
+            encoding_out = np.int16
         else:
-            if out is not None:
-                logger.info("[SoX] {}".format(out))
-            return True
+            encoding_out = [
+                k for k, v in ENCODINGS_MAPPING.items()
+                if input_format['file_type'] == v
+            ][0]
+
+        n_bits = np.dtype(encoding_out).itemsize * 8
+
+        output_format = {
+            'file_type': 'raw',
+            'rate': sample_rate_in,
+            'bits': n_bits,
+            'channels': input_format['channels'],
+            'encoding': None,
+            'comments': None,
+            'append_comments': True,
+        }
+
+        if self.output_format.get('rate') is not None:
+            output_format['rate'] = self.output_format['rate']
+
+        if self.output_format.get('channels') is not None:
+            output_format['channels'] = self.output_format['channels']
+
+        if self.output_format.get('bits') is not None:
+            output_format['bits'] = self.output_format['bits']
+
+        if n_bits == 8:
+            encoding_out = np.int8
+        elif n_bits == 16:
+            encoding_out = np.int16
+        elif n_bits == 32:
+            encoding_out = np.float32
+        elif n_bits == 64:
+            encoding_out = np.float64
+        else:
+            raise ValueError("invalid n_bits {}".format(n_bits))
+
+        args = []
+        args.extend(self.globals)
+        args.extend(self._input_format_args(input_format))
+        args.append(input_filepath)
+        args.extend(self._output_format_args(output_format))
+        args.append(output_filepath)
+        args.extend(self.effects)
+
+        if extra_args is not None:
+            if not isinstance(extra_args, list):
+                raise ValueError("extra_args must be a list.")
+            args.extend(extra_args)
+
+        status, out, err = sox(args, input_array, False)
+        if status != 0:
+            raise SoxError(
+                "Stdout: {}\nStderr: {}".format(out, err)
+            )
+
+        out = np.frombuffer(out, dtype=encoding_out)
+        if output_format['channels'] > 1:
+            out = out.reshape(
+                (
+                    output_format['channels'],
+                    int(len(out) / output_format['channels'])
+                ), order='F'
+            ).T
+        logger.info(
+            "Created array with effects: %s",
+            " ".join(self.effects_log)
+        )
+
+        return out
 
     def preview(self, input_filepath):
         '''Play a preview of the output with the current set of effects
@@ -1219,13 +1445,13 @@ class Transformer(object):
                 raise ValueError(
                     "bitdepth must be one of {}.".format(str(bitdepths))
                 )
-            self.output_format.extend(['-b', '{}'.format(bitdepth)])
+            self.output_format['bits'] = bitdepth
         if n_channels is not None:
             if not isinstance(n_channels, int) or n_channels <= 0:
                 raise ValueError(
                     "n_channels must be a positive integer."
                 )
-            self.output_format.extend(['-c', '{}'.format(n_channels)])
+            self.output_format['channels'] = n_channels
         if samplerate is not None:
             if not is_number(samplerate) or samplerate <= 0:
                 raise ValueError("samplerate must be a positive number.")
@@ -2072,7 +2298,7 @@ class Transformer(object):
                 "profile_path {} is not writeable.".format(_abs_profile_path))
 
         effect_args = ['noiseprof', profile_path]
-        self.build(input_filepath, None, extra_args=effect_args)
+        self.build(input_filepath, '-n', extra_args=effect_args)
 
         return None
 
@@ -2841,7 +3067,7 @@ class Transformer(object):
         lines = stat_output.split('\n')
         for line in lines:
             split_line = line.split()
-            if len(split_line) == 0:
+            if not split_line:
                 continue
             value = split_line[-1]
             key = ' '.join(split_line[:-1])
@@ -2872,7 +3098,7 @@ class Transformer(object):
         effect_args = ['channels', '1', 'stat', '-freq']
 
         _, _, stat_output = self.build(
-            input_filepath, None, extra_args=effect_args, return_output=True
+            input_filepath, '-n', extra_args=effect_args, return_output=True
         )
 
         power_spectrum = []

--- a/sox/transform.py
+++ b/sox/transform.py
@@ -814,7 +814,8 @@ class Transformer(object):
             output_format['channels'] = self.output_format['channels']
 
         if self.output_format.get('bits') is not None:
-            output_format['bits'] = self.output_format['bits']
+            n_bits = self.output_format['bits']
+            output_format['bits'] = n_bits
 
         if n_bits == 8:
             encoding_out = np.int8

--- a/sox/version.py
+++ b/sox/version.py
@@ -3,4 +3,4 @@
 """Version info"""
 
 short_version = '1.4'
-version = '1.4.0a0'
+version = '1.4.0a1'

--- a/tests/test_combine.py
+++ b/tests/test_combine.py
@@ -31,7 +31,7 @@ class TestCombineDefault(unittest.TestCase):
         self.assertEqual(expected, actual)
 
     def test_output_format(self):
-        expected = []
+        expected = {}
         actual = self.cbn.output_format
         self.assertEqual(expected, actual)
 
@@ -66,6 +66,15 @@ class TestCombineDefault(unittest.TestCase):
             cbn.build(
                 [INPUT_FILE_INVALID, INPUT_WAV], OUTPUT_FILE, 'concatenate'
             )
+
+    def test_build_with_output_format(self):
+        expected_result = True
+        cbn = new_combiner()
+        cbn.set_output_format(rate=8000)
+        actual_result = self.cbn.build(
+            [INPUT_WAV, INPUT_WAV], OUTPUT_FILE, 'concatenate'
+        )
+        self.assertEqual(expected_result, actual_result)
 
 
 class TestCombineTypes(unittest.TestCase):

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -720,25 +720,85 @@ class TestTransformerBuild(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.tfm.build(input_array=np.array([1, 2, 3]))
 
+    def test_no_output_file(self):
+        with self.assertRaises(ValueError):
+            self.tfm.build(INPUT_FILE)
+
     def test_no_input(self):
         with self.assertRaises(ValueError):
             self.tfm.build()
 
+
+class TestTransformerBuildArray(unittest.TestCase):
+    def setUp(self):
+        self.tfm = new_transformer()
+
+    def test_valid(self):
+        arr_out = self.tfm.build_array(INPUT_FILE)
+        self.assertTrue(isinstance(arr_out, np.ndarray))
+
+    def test_valid_spacey(self):
+        arr_out = self.tfm.build_array(SPACEY_FILE)
+        self.assertTrue(isinstance(arr_out, np.ndarray))
+
+    def test_extra_arg(self):
+        arr_out = self.tfm.build_array(INPUT_FILE, extra_args=['norm'])
+        self.assertTrue(isinstance(arr_out, np.ndarray))
+
+    def test_invalid(self):
+        with self.assertRaises(IOError):
+            self.tfm.build_array('blah/asdf.wav')
+
+    def test_invalid_input_type(self):
+        with self.assertRaises(TypeError):
+            self.tfm.build_array({'not a string or numpy array'})
+
+    def test_extra_args_invalid(self):
+        with self.assertRaises(ValueError):
+            self.tfm.build_array(INPUT_FILE, extra_args=0)
+
+    def test_failed_sox(self):
+        self.tfm.effects = ['channels', '-1']
+        with self.assertRaises(SoxError):
+            self.tfm.build_array(INPUT_FILE)
+
+    def test_two_inputs(self):
+        with self.assertRaises(ValueError):
+            self.tfm.build_array(
+                input_filepath=INPUT_FILE, input_array=np.array([1, 2]))
+
+    def test_input_array_not_array(self):
+        with self.assertRaises(TypeError):
+            self.tfm.build_array(input_array=[1, 2, 3])
+
+    def test_input_array_missing_sr(self):
+        with self.assertRaises(ValueError):
+            self.tfm.build_array(input_array=np.array([1, 2, 3]))
+
+    def test_no_input(self):
+        with self.assertRaises(ValueError):
+            self.tfm.build_array()
+
     def test_bits8(self):
-        self.tfm.set_output_format(file_type='wav', bits=8)
-        self.tfm.build(INPUT_FILE, OUTPUT_FILE)
+        self.tfm.set_output_format(bits=8)
+        arr_out = self.tfm.build_array(INPUT_FILE)
+        self.assertEqual(arr_out.dtype, np.int8)
 
     def test_bits16(self):
-        self.tfm.set_output_format(file_type='wav', bits=16)
-        self.tfm.build(INPUT_FILE, OUTPUT_FILE)
+        self.tfm.set_output_format(bits=16)
+        arr_out = self.tfm.build_array(INPUT_FILE)
+        self.assertEqual(arr_out.dtype, np.int16)
 
     def test_bits32(self):
-        self.tfm.set_output_format(file_type='wav', bits=32)
-        self.tfm.build(INPUT_FILE, OUTPUT_FILE)
+        self.tfm.set_output_format(bits=32)
+        arr_out = self.tfm.build_array(INPUT_FILE)
+        self.assertEqual(arr_out.dtype, np.float32)
 
     def test_bits64(self):
-        self.tfm.set_output_format(file_type='wav', bits=64)
-        self.tfm.build(INPUT_FILE, OUTPUT_FILE)
+        self.tfm.set_output_format(bits=64)
+        arr_out = self.tfm.build_array(INPUT_FILE)
+        self.assertEqual(arr_out.dtype, np.float64)
+
 
 class TestTransformerClearEffects(unittest.TestCase):
 

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -799,6 +799,11 @@ class TestTransformerBuildArray(unittest.TestCase):
         arr_out = self.tfm.build_array(INPUT_FILE)
         self.assertEqual(arr_out.dtype, np.float64)
 
+    def test_bits_invalid(self):
+        self.tfm.set_output_format(bits=17)
+        with self.assertRaises(ValueError):
+            self.tfm.build_array(INPUT_FILE)
+
 
 class TestTransformerClearEffects(unittest.TestCase):
 


### PR DESCRIPTION
Implements option B from issue #106 
* `build_file` takes array or file inputs and generates file outputs, returning a boolean
* `build_array` takes array or file inputs and returns np.ndarray outputs

`build_file` is an alias for `build`, and I moved the documentation to point people towards using `build_file`, while keeping `build` fully functional.

I also did a little cleanup of how `set_input_format` and `set_output_format` work - rather than storing the list of format arguments to be passed to sox, it stores a dictionary which is parsed when running `build`/`build_array`, which cleans up the build functions substantially.