### PR TITLE
Transformer.stretch performing reverse operation than expected

### DIFF
--- a/sox/transform.py
+++ b/sox/transform.py
@@ -3200,7 +3200,7 @@ class Transformer(object):
                 "window must be a positive number."
             )
 
-        effect_args = ['stretch', '{:f}'.format(factor), '{:f}'.format(window)]
+        effect_args = ['stretch', '{:f}'.format(1/factor), '{:f}'.format(window)]
 
         self.effects.extend(effect_args)
         self.effects_log.append('stretch')

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -4816,7 +4816,7 @@ class TestTransformerStretch(unittest.TestCase):
 
     def test_default(self):
         tfm = new_transformer()
-        tfm.stretch(1.1)
+        tfm.stretch(1/1.1)
 
         actual_args = tfm.effects
         expected_args = ['stretch', '1.100000', '20.000000']
@@ -4833,7 +4833,7 @@ class TestTransformerStretch(unittest.TestCase):
 
     def test_factor_valid(self):
         tfm = new_transformer()
-        tfm.stretch(0.7)
+        tfm.stretch(1/0.7)
 
         actual_args = tfm.effects
         expected_args = ['stretch', '0.700000', '20.000000']
@@ -4846,7 +4846,7 @@ class TestTransformerStretch(unittest.TestCase):
 
     def test_factor_extreme(self):
         tfm = new_transformer()
-        tfm.stretch(0.2)
+        tfm.stretch(1/0.2)
 
         actual_args = tfm.effects
         expected_args = ['stretch', '0.200000', '20.000000']
@@ -4864,7 +4864,7 @@ class TestTransformerStretch(unittest.TestCase):
 
     def test_window_valid(self):
         tfm = new_transformer()
-        tfm.stretch(0.99, window=10)
+        tfm.stretch(1/0.99, window=10)
 
         actual_args = tfm.effects
         expected_args = ['stretch', '0.990000', '10.000000']


### PR DESCRIPTION
Hi PySox team! I think I found a bug with `Transformer`, regarding the stretch effect. 

**Issue**:
According to [PySox docs](https://pysox.readthedocs.io/en/latest/api.html#sox.transform.Transformer.stretch), the `Transformer.stretch` hook should add a stretch effect where the parameter `factor` is the ratio of the new tempo to the old tempo. However, it appears to be the other way around, where it is the ratio of old tempo to new tempo. I have a [Jupyter notebook](https://nbviewer.jupyter.org/github/abugler/sox_tempo_stretch/blob/master/Tempo_Stretch.ipynb), comparing `tempo` and `stretch`, so you can also see the inconsistency with `tempo`. 

**Solution**:
Change line 3203 in `transform.py` from this:
```python
         effect_args = ['stretch', '{:f}'.format(factor), '{:f}'.format(window)]
```
to this.
```python
         effect_args = ['stretch', '{:f}'.format(1/factor), '{:f}'.format(window)]
```
I have made this change in the pull request!