### PR TITLE
Handle pathlib.Path path types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ sudo: false
 language: python
 
 python:
-  - "2.7"
   - "3.4"
   - "3.5"
+  - "3.6"
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ sudo: false
 language: python
 
 python:
-  - "3.4"
   - "3.5"
   - "3.6"
+  - "3.8"
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ language: python
 python:
   - "3.5"
   - "3.6"
+  - "3.7"
   - "3.8"
 
 addons:

--- a/sox/combine.py
+++ b/sox/combine.py
@@ -430,6 +430,8 @@ def _build_input_args(input_filepath_list, input_format_list):
     ''' Builds input arguments by stitching input filepaths and input
     formats together.
     '''
+    # Convert pathlib.Paths to strings.
+    input_filepath_list = [str(x) for x in input_filepath_list]
     if len(input_format_list) != len(input_filepath_list):
         raise ValueError(
             "input_format_list & input_filepath_list are not the same size"

--- a/sox/core.py
+++ b/sox/core.py
@@ -42,6 +42,9 @@ def sox(args, src_array=None, decode_out_with_utf=True):
         Returns stderr as a string.
 
     '''
+    # Explicitly convert python3 pathlib.Path objects to strings.
+    args = [str(x) for x in args]
+
     if args[0].lower() != "sox":
         args.insert(0, "sox")
     else:

--- a/sox/core.py
+++ b/sox/core.py
@@ -1,10 +1,13 @@
 '''Base module for calling SoX '''
-from .log import logger
 
+from pathlib import Path
 import subprocess
 from subprocess import CalledProcessError
+from typing import Union
+
 import numpy as np
 
+from .log import logger
 from . import NO_SOX
 
 SOXI_ARGS = ['B', 'b', 'c', 'a', 'D', 'e', 't', 's', 'r']
@@ -122,12 +125,12 @@ def _get_valid_formats():
 VALID_FORMATS = _get_valid_formats()
 
 
-def soxi(filepath, argument):
+def soxi(filepath: Union[str, Path], argument: str) -> str:
     ''' Base call to SoXI.
 
     Parameters
     ----------
-    filepath : str
+    filepath : path-like (str or pathlib.Path)
         Path to audio file.
 
     argument : str
@@ -138,6 +141,7 @@ def soxi(filepath, argument):
     shell_output : str
         Command line output of SoXI
     '''
+    filepath = str(filepath)
 
     if argument not in SOXI_ARGS:
         raise ValueError("Invalid argument '{}' to SoXI".format(argument))
@@ -175,6 +179,9 @@ def play(args):
         True on success.
 
     '''
+    # Make sure all inputs are strings (eg not pathlib.Path)
+    args = [str(x) for x in args]
+
     if args[0].lower() != "play":
         args.insert(0, "play")
     else:

--- a/sox/file_info.py
+++ b/sox/file_info.py
@@ -1,15 +1,16 @@
 ''' Audio file info computed by soxi.
 '''
-from .log import logger
-
 import os
+from pathlib import Path
+from typing import Optional, Union
 
 from .core import VALID_FORMATS
 from .core import soxi
 from .core import sox
+from .log import logger
 
 
-def bitdepth(input_filepath):
+def bitdepth(input_filepath: Union[str, Path]) -> Optional[int]:
     '''
     Number of bits per sample, or None if not applicable.
 
@@ -33,7 +34,7 @@ def bitdepth(input_filepath):
     return int(output)
 
 
-def bitrate(input_filepath):
+def bitrate(input_filepath: Union[str, Path]) -> Optional[float]:
     '''
     Bit rate averaged over the whole file.
     Expressed in bytes per second (bps), or None if not applicable.
@@ -64,7 +65,7 @@ def bitrate(input_filepath):
         return float(output[:-1])
 
 
-def channels(input_filepath):
+def channels(input_filepath: Union[str, Path]) -> int:
     '''
     Show number of channels.
 
@@ -83,7 +84,7 @@ def channels(input_filepath):
     return int(output)
 
 
-def comments(input_filepath):
+def comments(input_filepath: Union[str, Path]) -> str:
     '''
     Show file comments (annotations) if available.
 
@@ -103,7 +104,7 @@ def comments(input_filepath):
     return str(output)
 
 
-def duration(input_filepath):
+def duration(input_filepath: Union[str, Path]) -> float:
     '''
     Show duration in seconds, or None if not available.
 
@@ -126,7 +127,7 @@ def duration(input_filepath):
     return float(output)
 
 
-def encoding(input_filepath):
+def encoding(input_filepath: Union[str, Path]) -> str:
     '''
     Show the name of the audio encoding.
 
@@ -145,7 +146,7 @@ def encoding(input_filepath):
     return str(output)
 
 
-def file_type(input_filepath):
+def file_type(input_filepath: Union[str, Path]) -> str:
     '''
     Show detected file-type.
 
@@ -164,13 +165,13 @@ def file_type(input_filepath):
     return str(output)
 
 
-def num_samples(input_filepath):
+def num_samples(input_filepath: Union[str, Path]) -> Optional[int]:
     '''
     Show number of samples, or None if unavailable.
 
     Parameters
     ----------
-    input_filepath : str
+    input_filepath : path-like (str or pathlib.Path)
         Path to audio file.
 
     Returns
@@ -179,6 +180,7 @@ def num_samples(input_filepath):
         total number of samples in audio file.
         Returns None if empty or unavailable.
     '''
+    input_filepath = str(input_filepath)
     validate_input_file(input_filepath)
     output = soxi(input_filepath, 's')
     if output == '0':
@@ -187,7 +189,7 @@ def num_samples(input_filepath):
     return int(output)
 
 
-def sample_rate(input_filepath):
+def sample_rate(input_filepath: Union[str, Path]) -> float:
     '''
     Show sample-rate.
 
@@ -206,7 +208,7 @@ def sample_rate(input_filepath):
     return float(output)
 
 
-def silent(input_filepath, threshold=0.001):
+def silent(input_filepath: Union[str, Path], threshold:float = 0.001) -> bool:
     '''
     Determine if an input file is silent.
 
@@ -234,17 +236,18 @@ def silent(input_filepath, threshold=0.001):
         return True
 
 
-def validate_input_file(input_filepath):
+def validate_input_file(input_filepath: Union[str, Path]) -> None:
     '''Input file validation function. Checks that file exists and can be
     processed by SoX.
 
     Parameters
     ----------
-    input_filepath : str
+    input_filepath : path-like (str or pathlib.Path)
         The input filepath.
 
     '''
-    if not os.path.exists(input_filepath):
+    input_filepath = Path(input_filepath)
+    if not input_filepath.exists():
         raise IOError(
             "input_filepath {} does not exist.".format(input_filepath)
         )
@@ -256,7 +259,7 @@ def validate_input_file(input_filepath):
         )
 
 
-def validate_input_file_list(input_filepath_list):
+def validate_input_file_list(input_filepath_list: Union[str, Path]) -> None:
     '''Input file list validation function. Checks that object is a list and
     contains valid filepaths that can be processed by SoX.
 
@@ -275,17 +278,21 @@ def validate_input_file_list(input_filepath_list):
         validate_input_file(input_filepath)
 
 
-def validate_output_file(output_filepath):
+def validate_output_file(output_filepath: Union[str, Path]) -> None:
     '''Output file validation function. Checks that file can be written, and
     has a valid file extension. Throws a warning if the path already exists,
     as it will be overwritten on build.
 
     Parameters
     ----------
-    output_filepath : str
+    output_filepath : path-like (str or pathlib.Path)
         The output filepath.
 
     '''
+    # This function enforces use of the path as a string, becasue
+    # os.access has no analog in pathlib.
+    output_filepath = str(output_filepath)
+
     if output_filepath == '-n':
         return
 
@@ -313,12 +320,12 @@ def validate_output_file(output_filepath):
         )
 
 
-def file_extension(filepath):
+def file_extension(filepath: Union[str, Path]):
     '''Get the extension of a filepath.
 
     Parameters
     ----------
-    filepath : str
+    filepath : path-like (str or pathlib.Path)
         File path.
 
     Returns
@@ -326,10 +333,10 @@ def file_extension(filepath):
     extension : str
         The file's extension
     '''
-    return os.path.splitext(filepath)[1][1:].lower()
+    return Path(filepath).suffix[1:].lower()
 
 
-def info(filepath):
+def info(filepath: Union[str, Path]) -> dict:
     '''Get a dictionary of file information
 
     Parameters
@@ -363,7 +370,7 @@ def info(filepath):
     return info_dictionary
 
 
-def stat(filepath):
+def stat(filepath: Union[str, Path]) -> dict:
     '''Returns a dictionary of audio statistics.
 
     Parameters
@@ -381,7 +388,7 @@ def stat(filepath):
     return stat_dictionary
 
 
-def _stat_call(filepath):
+def _stat_call(filepath: Union[str, Path]) -> str:
     '''Call sox's stat function.
 
     Parameters
@@ -400,7 +407,7 @@ def _stat_call(filepath):
     return stat_output
 
 
-def _parse_stat(stat_output):
+def _parse_stat(stat_output: Union[str, Path]) -> dict:
     '''Parse the string output from sox's stat function
 
     Parameters

--- a/sox/file_info.py
+++ b/sox/file_info.py
@@ -289,7 +289,7 @@ def validate_output_file(output_filepath: Union[str, Path]) -> None:
         The output filepath.
 
     '''
-    # This function enforces use of the path as a string, becasue
+    # This function enforces use of the path as a string, because
     # os.access has no analog in pathlib.
     output_filepath = str(output_filepath)
 

--- a/tests/test_combine.py
+++ b/tests/test_combine.py
@@ -1,5 +1,6 @@
-import unittest
+from pathlib import Path
 import os
+import unittest
 
 from sox import combine
 from sox.core import SoxError
@@ -49,6 +50,13 @@ class TestCombineDefault(unittest.TestCase):
         expected_result = True
         actual_result = self.cbn.build(
             [INPUT_WAV, INPUT_WAV], OUTPUT_FILE, 'concatenate'
+        )
+        self.assertEqual(expected_result, actual_result)
+
+    def test_build_pathlib(self):
+        expected_result = True
+        actual_result = self.cbn.build(
+            [Path(INPUT_WAV), (INPUT_WAV)], Path(OUTPUT_FILE), 'concatenate'
         )
         self.assertEqual(expected_result, actual_result)
 
@@ -403,6 +411,12 @@ class TestCombinePreview(unittest.TestCase):
         actual = self.cbn.preview([INPUT_WAV, INPUT_WAV], 'mix', [1.0, 0.5])
         self.assertEqual(expected, actual)
 
+    def test_valid_pathlib(self):
+        expected = None
+        actual = self.cbn.preview([Path(INPUT_WAV), Path(INPUT_WAV)], 'mix')
+        self.assertEqual(expected, actual)
+
+
 
 class TestBuildInputArgs(unittest.TestCase):
 
@@ -414,6 +428,13 @@ class TestBuildInputArgs(unittest.TestCase):
         expected = ['-v', '1', INPUT_WAV, '-v', '1', INPUT_WAV]
         actual = combine._build_input_args(
             [INPUT_WAV, INPUT_WAV], [['-v', '1'], ['-v', '1']]
+        )
+        self.assertEqual(expected, actual)
+
+    def test_handles_pathlib(self):
+        expected = ['-v', '1', INPUT_WAV, '-v', '1', INPUT_WAV]
+        actual = combine._build_input_args(
+            [Path(INPUT_WAV), Path(INPUT_WAV)], [['-v', '1'], ['-v', '1']]
         )
         self.assertEqual(expected, actual)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 import unittest
 import os
 
@@ -20,6 +21,12 @@ class TestSox(unittest.TestCase):
 
     def test_base_case(self):
         args = ['sox', INPUT_FILE, OUTPUT_FILE]
+        expected = (0, '', '')
+        actual = core.sox(args)
+        self.assertEqual(expected, actual)
+
+    def test_base_case_pathlib(self):
+        args = ['sox', Path(INPUT_FILE), Path(OUTPUT_FILE)]
         expected = (0, '', '')
         actual = core.sox(args)
         self.assertEqual(expected, actual)
@@ -122,6 +129,11 @@ class TestSoxi(unittest.TestCase):
         expected = '441000'
         self.assertEqual(expected, actual)
 
+    def test_base_case_pathlib(self):
+        actual = core.soxi(Path(INPUT_FILE), 's')
+        expected = '441000'
+        self.assertEqual(expected, actual)
+
     def test_spacey_wav(self):
         actual = core.soxi(SPACEY_FILE, 's')
         expected = '80000'
@@ -149,6 +161,12 @@ class TestPlay(unittest.TestCase):
 
     def test_base_case(self):
         args = ['play', 'data/input.aiff', 'trim', '0', '0.1']
+        expected = True
+        actual = core.play(args)
+        self.assertEqual(expected, actual)
+
+    def test_base_pathlib(self):
+        args = ['play', Path('data/input.aiff'), 'trim', '0', '0.1']
         expected = True
         actual = core.play(args)
         self.assertEqual(expected, actual)
@@ -182,6 +200,7 @@ class TestPlay(unittest.TestCase):
         expected = False
         actual = core.play(args)
         self.assertEqual(expected, actual)
+
 
 
 class TestIsNumber(unittest.TestCase):

--- a/tests/test_file_info.py
+++ b/tests/test_file_info.py
@@ -1,5 +1,6 @@
-import unittest
+from pathlib import Path
 import os
+import unittest
 
 from sox import file_info
 from sox.core import SoxError
@@ -26,6 +27,11 @@ class TestBitrate(unittest.TestCase):
         expected = 706000.0
         self.assertEqual(expected, actual)
 
+    def test_wav_pathlib(self):
+        actual = file_info.bitrate(Path(INPUT_FILE))
+        expected = 706000.0
+        self.assertEqual(expected, actual)
+
     def test_aiff(self):
         actual = file_info.bitrate(INPUT_FILE2)
         expected = 768000.0
@@ -36,10 +42,17 @@ class TestBitrate(unittest.TestCase):
         expected = None
         self.assertEqual(expected, actual)
 
+
+
 class TestBitdepth(unittest.TestCase):
 
     def test_wav(self):
         actual = file_info.bitdepth(INPUT_FILE)
+        expected = 16
+        self.assertEqual(expected, actual)
+
+    def test_wav_pathlib(self):
+        actual = file_info.bitdepth(Path(INPUT_FILE))
         expected = 16
         self.assertEqual(expected, actual)
 
@@ -66,6 +79,11 @@ class TestChannels(unittest.TestCase):
         expected = 1
         self.assertEqual(expected, actual)
 
+    def test_wav_pathlib(self):
+        actual = file_info.channels(Path(INPUT_FILE))
+        expected = 1
+        self.assertEqual(expected, actual)
+
     def test_aiff(self):
         actual = file_info.channels(INPUT_FILE2)
         expected = 3
@@ -84,6 +102,11 @@ class TestComments(unittest.TestCase):
         expected = ""
         self.assertEqual(expected, actual)
 
+    def test_wav_pathlib(self):
+        actual = file_info.comments(Path(INPUT_FILE))
+        expected = ""
+        self.assertEqual(expected, actual)
+
     def test_aiff(self):
         actual = file_info.comments(INPUT_FILE2)
         expected = "Processed by SoX"
@@ -99,6 +122,11 @@ class TestDuration(unittest.TestCase):
 
     def test_wav(self):
         actual = file_info.duration(INPUT_FILE)
+        expected = 10.0
+        self.assertEqual(expected, actual)
+
+    def test_wav_pathlib(self):
+        actual = file_info.duration(Path(INPUT_FILE))
         expected = 10.0
         self.assertEqual(expected, actual)
 
@@ -125,6 +153,11 @@ class TestEncoding(unittest.TestCase):
         expected = "Signed Integer PCM"
         self.assertEqual(expected, actual)
 
+    def test_wav_pathlib(self):
+        actual = file_info.encoding(Path(INPUT_FILE))
+        expected = "Signed Integer PCM"
+        self.assertEqual(expected, actual)
+
     def test_aiff(self):
         actual = file_info.encoding(INPUT_FILE2)
         expected = "Signed Integer PCM"
@@ -140,6 +173,11 @@ class TestFileType(unittest.TestCase):
 
     def test_wav(self):
         actual = file_info.file_type(INPUT_FILE)
+        expected = "wav"
+        self.assertEqual(expected, actual)
+
+    def test_wav_pathlib(self):
+        actual = file_info.file_type(Path(INPUT_FILE))
         expected = "wav"
         self.assertEqual(expected, actual)
 
@@ -161,6 +199,11 @@ class TestNumSamples(unittest.TestCase):
         expected = 441000
         self.assertEqual(expected, actual)
 
+    def test_wav_pathlib(self):
+        actual = file_info.num_samples(Path(INPUT_FILE))
+        expected = 441000
+        self.assertEqual(expected, actual)
+
     def test_aiff(self):
         actual = file_info.num_samples(INPUT_FILE2)
         expected = 80000
@@ -176,6 +219,11 @@ class TestSampleRate(unittest.TestCase):
 
     def test_wav(self):
         actual = file_info.sample_rate(INPUT_FILE)
+        expected = 44100
+        self.assertEqual(expected, actual)
+
+    def test_wav_pathlib(self):
+        actual = file_info.sample_rate(Path(INPUT_FILE))
         expected = 44100
         self.assertEqual(expected, actual)
 
@@ -197,6 +245,11 @@ class TestSilent(unittest.TestCase):
         expected = False
         self.assertEqual(expected, actual)
 
+    def test_nonsilent_pathlib(self):
+        actual = file_info.silent(Path(INPUT_FILE))
+        expected = False
+        self.assertEqual(expected, actual)
+
     def test_silent(self):
         actual = file_info.silent(SILENT_FILE)
         expected = True
@@ -212,6 +265,11 @@ class TestFileExtension(unittest.TestCase):
 
     def test_ext1(self):
         actual = file_info.file_extension('simplefile.xyz')
+        expected = 'xyz'
+        self.assertEqual(expected, actual)
+
+    def test_ext1_pathlib(self):
+        actual = file_info.file_extension(Path('simplefile.xyz'))
         expected = 'xyz'
         self.assertEqual(expected, actual)
 
@@ -244,24 +302,33 @@ class TestFileExtension(unittest.TestCase):
 class TestInfo(unittest.TestCase):
 
     def test_dictionary(self):
-        actual = file_info.info(INPUT_FILE)
-        expected = {
-            'channels': 1,
-            'sample_rate': 44100.0,
-            'bitdepth': 16,
-            'bitrate': 706000.0,
-            'duration': 10.0,
-            'num_samples': 441000,
-            'encoding': 'Signed Integer PCM',
-            'silent': False
-        }
-        self.assertEqual(expected, actual)
+        for use_pathlib in [False, True]:
+            with self.subTest():
+                input_file = Path(INPUT_FILE) if use_pathlib else INPUT_FILE
+
+                actual = file_info.info(input_file)
+                expected = {
+                    'channels': 1,
+                    'sample_rate': 44100.0,
+                    'bitdepth': 16,
+                    'bitrate': 706000.0,
+                    'duration': 10.0,
+                    'num_samples': 441000,
+                    'encoding': 'Signed Integer PCM',
+                    'silent': False
+                }
+                self.assertEqual(expected, actual)
 
 
 class TestValidateInputFile(unittest.TestCase):
 
     def test_valid(self):
         actual = file_info.validate_input_file(INPUT_FILE)
+        expected = None
+        self.assertEqual(expected, actual)
+
+    def test_valid_pathlib(self):
+        actual = file_info.validate_input_file(Path(INPUT_FILE))
         expected = None
         self.assertEqual(expected, actual)
 

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -1,5 +1,6 @@
-import unittest
+from pathlib import Path
 import os
+import unittest
 
 from sox import transform, file_info
 from sox.core import SoxError
@@ -95,6 +96,15 @@ class TestTransformSetGlobals(unittest.TestCase):
         self.assertEqual(expected, actual)
 
         actual_result = self.tfm.build(INPUT_FILE, OUTPUT_FILE)
+        expected_result = True
+        self.assertEqual(expected_result, actual_result)
+
+    def test_defaults_pathlib(self):
+        actual = self.tfm.globals
+        expected = ['-D', '-V2']
+        self.assertEqual(expected, actual)
+
+        actual_result = self.tfm.build(Path(INPUT_FILE), Path(OUTPUT_FILE))
         expected_result = True
         self.assertEqual(expected_result, actual_result)
 


### PR DESCRIPTION
Since python 3.4 there has been a new [object-oriented interface](https://docs.python.org/3/library/pathlib.html) to handling paths. This PR adds support for `pathlib.Path` for functions which take a path as input. I make heavy use of `pathlib.Path` in my code these days, and while I can do the cast to string myself, I find that more and more libraries are supporting pathlib, and so I offer this PR.

In practice, since `pathlib.Path` is implicitly cast to string, there are only a couple of minor places where this is important - any function which performs a string-based operation on a variable which *could* be a path.

In order to make sure the tests pass, because this a python3-only feature, I also removed 2.7 from your `.travis.yml` file. Since [python2 is EOL](https://www.python.org/doc/sunset-python-2/), and your readme doesn't include a python2 badge in the top, it seemed like this should be okay. If not, let me know and I'll see if I can come up with some test flags for python2 which would skip these tests or something.