### PR TITLE
Fix soxi returning \r char on Windows

### DIFF
--- a/sox/core.py
+++ b/sox/core.py
@@ -170,7 +170,7 @@ def soxi(filepath: Union[str, Path], argument: str) -> str:
 
     shell_output = shell_output.decode("utf-8")
 
-    return str(shell_output).strip('\n')
+    return str(shell_output).strip('\n\r')
 
 
 def play(args: Iterable[str]) -> bool:


### PR DESCRIPTION
Core function soxi which executes sox --i command
strips the \n character. This does not cover usage
on a Windows machine.