### PR TITLE
Fix bitrate parsing for cross-platform environment

### DIFF
--- a/sox/file_info.py
+++ b/sox/file_info.py
@@ -56,13 +56,17 @@ def bitrate(input_filepath: Union[str, Path]) -> Optional[float]:
     validate_input_file(input_filepath)
     output = soxi(input_filepath, 'B')
     # The characters below stand for kilo, Mega, Giga, etc.
-    greek_prefixes = '\0kMGTPEZY'
+    # greek_prefix might not be the last character in string in cross platform
+    # environment - \r\n
+    greek_prefixes = '\0KMGTPEZY'
+    greek_index = [n for n, p in enumerate(greek_prefixes) if p in output.upper()]
     if output == "0":
         logger.warning("Bit rate unavailable for %s", input_filepath)
         return None
-    elif output[-1] in greek_prefixes:
-        multiplier = 1000.0**(greek_prefixes.index(output[-1]))
-        return float(output[:-1])*multiplier
+    elif greek_index:
+        assert len(greek_index) == 1
+        multiplier = 1000.0**greek_index[0]
+        return float(output[:greek_index[0]])*multiplier
     else:
         return float(output[:-1])
 


### PR DESCRIPTION
Previous version of parsing was unable to get valid content
eg. when `output` ends with '\r' character what is possible
in cross platform environment. New parser version is resistant
for any line ending.
Moreover parser is insensistive for prefix letter size, see bug:
https://github.com/rabitt/pysox/issues/119#issuecomment-732651583

Signed-off-by: Karol Trzcinski <k.trzcinski95@gmail.com>