### PR TITLE
add input_array and sample_rate_in arguments to stat, stats and power…

### DIFF
--- a/sox/transform.py
+++ b/sox/transform.py
@@ -3131,7 +3131,9 @@ class Transformer:
         return self
 
     def stat(self,
-             input_filepath: Union[str, Path],
+             input_filepath: Optional[Union[str, Path]] = None,
+             input_array: Optional[np.ndarray] = None,
+             sample_rate_in: Optional[float] = None,
              scale: Optional[float] = None,
              rms: Optional[bool] = False):
         '''Display time and frequency domain statistical information about the
@@ -3145,8 +3147,13 @@ class Transformer:
 
         Parameters
         ----------
-        input_filepath : str
+        input_filepath : str or None
             Path to input file to compute stats on.
+        input_array : np.ndarray or None
+            A np.ndarray of an waveform with shape (n_samples, n_channels)
+            or None
+        sample_rate_in : int or None
+            Sample rate of input_array or None
         scale : float or None, default=None
             If not None, scales the input by the given scale factor.
         rms : bool, default=False
@@ -3171,7 +3178,8 @@ class Transformer:
             effect_args.append('-rms')
 
         _, _, stat_output = self.build(
-            input_filepath, '-n', extra_args=effect_args, return_output=True
+            input_filepath=input_filepath, input_array=input_array, sample_rate_in=sample_rate_in,
+            output_filepath='-n', extra_args=effect_args, return_output=True
         )
 
         stat_dict = {}
@@ -3186,7 +3194,10 @@ class Transformer:
 
         return stat_dict
 
-    def power_spectrum(self, input_filepath: Union[str, Path]):
+    def power_spectrum(self,
+             input_filepath: Optional[Union[str, Path]] = None,
+             input_array: Optional[np.ndarray] = None,
+             sample_rate_in: Optional[float] = None):
         '''Calculates the power spectrum (4096 point DFT). This method
         internally invokes the stat command with the -freq option.
 
@@ -3194,8 +3205,13 @@ class Transformer:
 
         Parameters
         ----------
-        input_filepath : str
+        input_filepath : str or None
             Path to input file to compute stats on.
+        input_array : np.ndarray or None
+            A np.ndarray of an waveform with shape (n_samples, n_channels)
+            or None
+        sample_rate_in : int or None
+            Sample rate of input_array or None
 
         Returns
         -------
@@ -3209,7 +3225,8 @@ class Transformer:
         effect_args = ['channels', '1', 'stat', '-freq']
 
         _, _, stat_output = self.build(
-            input_filepath, '-n', extra_args=effect_args, return_output=True
+            input_filepath=input_filepath, input_array=input_array, sample_rate_in=sample_rate_in,
+            output_filepath='-n', extra_args=effect_args, return_output=True
         )
 
         power_spectrum = []
@@ -3224,7 +3241,10 @@ class Transformer:
 
         return power_spectrum
 
-    def stats(self, input_filepath: Union[str, Path]):
+    def stats(self,
+             input_filepath: Optional[Union[str, Path]] = None,
+             input_array: Optional[np.ndarray] = None,
+             sample_rate_in: Optional[float] = None):
         '''Display time domain statistical information about the audio
         channels. Audio is passed unmodified through the SoX processing chain.
         Statistics are calculated and displayed for each audio channel
@@ -3237,8 +3257,13 @@ class Transformer:
 
         Parameters
         ----------
-        input_filepath : str
+        input_filepath : str or None
             Path to input file to compute stats on.
+        input_array : np.ndarray or None
+            A np.ndarray of an waveform with shape (n_samples, n_channels)
+            or None
+        sample_rate_in : int or None
+            Sample rate of input_array or None
 
         Returns
         -------
@@ -3252,7 +3277,8 @@ class Transformer:
         effect_args = ['channels', '1', 'stats']
 
         _, _, stats_output = self.build(
-            input_filepath, '-n', extra_args=effect_args, return_output=True
+            input_filepath=input_filepath, input_array=input_array, sample_rate_in=sample_rate_in,
+            output_filepath='-n', extra_args=effect_args, return_output=True
         )
 
         stats_dict = {}


### PR DESCRIPTION
Allow stat(), stats() and power_spectrum() to accept numpy arrays as well as file inputs.