### PR TITLE
Add support for filenames beginning with a dash

### DIFF
--- a/sox/core.py
+++ b/sox/core.py
@@ -157,6 +157,8 @@ def soxi(filepath: Union[str, Path], argument: str) -> str:
 
     args = ['sox', '--i']
     args.append("-{}".format(argument))
+    if filepath != "-n":
+        args.append("--")
     args.append(filepath)
 
     try:

--- a/sox/transform.py
+++ b/sox/transform.py
@@ -629,8 +629,12 @@ class Transformer:
         args = []
         args.extend(self.globals)
         args.extend(self._input_format_args(input_format))
+        if input_filepath != "-n":
+            args.append("--")
         args.append(input_filepath)
         args.extend(self._output_format_args(self.output_format))
+        if output_filepath != "-n":
+            args.append("--")
         args.append(output_filepath)
         args.extend(self.effects)
 
@@ -860,8 +864,12 @@ class Transformer:
         args = []
         args.extend(self.globals)
         args.extend(self._input_format_args(input_format))
+        if input_filepath != "-n":
+            args.append("--")
         args.append(input_filepath)
         args.extend(self._output_format_args(output_format))
+        if output_filepath != "-n":
+            args.append("--")
         args.append(output_filepath)
         args.extend(self.effects)
 
@@ -903,6 +911,7 @@ class Transformer:
         args = ["play", "--no-show-progress"]
         args.extend(self.globals)
         args.extend(self.input_format)
+        args.append("--")
         args.append(input_filepath)
         args.extend(self.effects)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import unittest
+import shutil
 import os
 
 from sox import core
@@ -11,6 +12,7 @@ def relpath(f):
 
 
 SPACEY_FILE = relpath("data/annoying filename (derp).wav")
+DASHED_FILE = "-dashed.wav"
 INPUT_FILE = relpath('data/input.wav')
 INPUT_FILE_INVALID = relpath('data/input.xyz')
 INPUT_FILE_CORRUPT = relpath('data/empty.aiff')
@@ -138,6 +140,13 @@ class TestSoxi(unittest.TestCase):
         actual = core.soxi(SPACEY_FILE, 's')
         expected = '80000'
         self.assertEqual(expected, actual)
+
+    def test_dashed_wav(self):
+        shutil.copyfile(INPUT_FILE, DASHED_FILE)
+        actual = core.soxi(DASHED_FILE, 's')
+        expected = '441000'
+        self.assertEqual(expected, actual)
+        os.unlink(DASHED_FILE)
 
     def test_invalid_argument(self):
         with self.assertRaises(ValueError):

--- a/tests/test_file_info.py
+++ b/tests/test_file_info.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import os
+import shutil
 import unittest
 
 from sox import file_info
@@ -11,6 +12,7 @@ def relpath(f):
 
 
 SPACEY_FILE = relpath("data/annoying filename (derp).wav")
+DASHED_FILE = "-dashed.wav"
 INPUT_FILE = relpath('data/input.wav')
 INPUT_FILE2 = relpath('data/input.aiff')
 INPUT_FILE3 = relpath('data/input.WAV')
@@ -134,6 +136,13 @@ class TestDuration(unittest.TestCase):
         actual = file_info.duration(SPACEY_FILE)
         expected = 10.0
         self.assertEqual(expected, actual)
+
+    def test_dashed_wav(self):
+        shutil.copyfile(INPUT_FILE, DASHED_FILE)
+        actual = file_info.duration(DASHED_FILE)
+        expected = 10.0
+        self.assertEqual(expected, actual)
+        os.unlink(DASHED_FILE)
 
     def test_aiff(self):
         actual = file_info.duration(INPUT_FILE2)
@@ -336,6 +345,13 @@ class TestValidateInputFile(unittest.TestCase):
         actual = file_info.validate_input_file(SPACEY_FILE)
         expected = None
         self.assertEqual(expected, actual)
+
+    def test_valid_wdash(self):
+        shutil.copyfile(INPUT_FILE, DASHED_FILE)
+        actual = file_info.validate_input_file(DASHED_FILE)
+        expected = None
+        self.assertEqual(expected, actual)
+        os.unlink(DASHED_FILE)
 
     def test_nonexistent(self):
         with self.assertRaises(IOError):

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import os
+import shutil
 import unittest
 
 from sox import transform, file_info
@@ -13,6 +14,8 @@ def relpath(f):
 
 
 SPACEY_FILE = relpath("data/annoying filename (derp).wav")
+DASHED_FILE = "-dashed.wav"
+DASHED_OUTPUT_FILE = "-dashed-output.wav"
 INPUT_FILE = relpath('data/input.wav')
 INPUT_FILE4 = relpath('data/input4.wav')
 OUTPUT_FILE = relpath('data/output.wav')
@@ -688,6 +691,13 @@ class TestTransformerBuild(unittest.TestCase):
         status = self.tfm.build(SPACEY_FILE, OUTPUT_FILE)
         self.assertTrue(status)
 
+    def test_valid_dashed(self):
+        shutil.copyfile(INPUT_FILE, DASHED_FILE)
+        status = self.tfm.build(DASHED_FILE, DASHED_OUTPUT_FILE)
+        self.assertTrue(status)
+        os.unlink(DASHED_FILE)
+        os.unlink(DASHED_OUTPUT_FILE)
+
     def test_null_output(self):
         status = self.tfm.build(INPUT_FILE, '-n')
         self.assertTrue(status)
@@ -750,6 +760,12 @@ class TestTransformerBuildArray(unittest.TestCase):
     def test_valid_spacey(self):
         arr_out = self.tfm.build_array(SPACEY_FILE)
         self.assertTrue(isinstance(arr_out, np.ndarray))
+
+    def test_valid_dashed(self):
+        shutil.copyfile(INPUT_FILE, DASHED_FILE)
+        arr_out = self.tfm.build_array(DASHED_FILE)
+        self.assertTrue(isinstance(arr_out, np.ndarray))
+        os.unlink(DASHED_FILE)
 
     def test_extra_arg(self):
         arr_out = self.tfm.build_array(INPUT_FILE, extra_args=['norm'])


### PR DESCRIPTION
I have a use case which requires support for filenames beginning with a dash (“-”). However, this is currently parsed as an extra argument, and causes sox/soxi to bail with an exit code of 1.

This PR addresses the issue by inserting a double-dash immediately before the filename (in input and output cases), and incorporates unit tests for these cases. 

Please let me know if you have any concerns or would like any changes. Thanks for the excellent library!