### PR TITLE
Remove deprecated `imp`

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,7 +15,6 @@
 
 import sys
 import os
-import imp
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,5 @@
 [metadata]
 description-file = README.md
+version = attr: sox.version.version
 [bdist_wheel]
 universal = 1

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,7 @@
 """ Setup script for sox. """
 from setuptools import setup
 
-import imp
 
-version = imp.load_source('sox.version', 'sox/version.py')
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
@@ -11,12 +9,11 @@ with open("README.md", "r") as fh:
 if __name__ == "__main__":
     setup(
         name='sox',
-        version=version.version,
         description='Python wrapper around SoX.',
         author='Rachel Bittner',
         author_email='rachel.bittner@nyu.edu',
         url='https://github.com/rabitt/pysox',
-        download_url='http://github.com/rabitt/pysox/releases',
+        download_url='https://github.com/rabitt/pysox/releases',
         packages=['sox'],
         package_data={'sox': []},
         long_description=long_description,


### PR DESCRIPTION
Fixes #158.

`imp` is imported in `docs/conf.py` but not used, so we can delete it.

`imp` in `setup.py` is used to read the version from `sox/version.py`, so we can instead replace with the suggestion from the Python Packaging User Guide on ["Single-sourcing the package version"](https://packaging.python.org/en/latest/guides/single-sourcing-package-version/#single-sourcing-the-package-version):

> As of the release of setuptools 46.4.0, one can accomplish the same thing by instead placing the following in the project’s `setup.cfg` file (replacing “package” with the import name of the package):
```cfg
[metadata]
version = attr: package.__version__
```
