### PR TITLE
MAINT pysoundfile -> soundfile

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -32,7 +32,7 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install flake8 pytest pytest-cov
         python -m pip install coveralls
-        python -m pip install pysoundfile
+        python -m pip install soundfile
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         python -m pip install -e .
         mkdir ${{ github.workspace }}/coverage

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ if __name__ == "__main__":
                 'pytest',
                 'pytest-cov',
                 'pytest-pep8',
-                'pysoundfile >= 0.9.0',
+                'soundfile >= 0.11.0',
             ],
             'docs': [
                 'sphinx==1.2.3',  # autodoc was broken in 1.3.1


### PR DESCRIPTION
Came up in conversation with @adinhodovic while reviewing #153. Quote from soundfile:

```
Breaking Changes
The soundfile module has evolved rapidly in the past. Most notably, we changed the import name from import pysoundfile to import soundfile in 0.7. In 0.6, we cleaned up many small inconsistencies, particularly in the the ordering and naming of function arguments and the removal of the indexing interface.
```

I believe this is urgent and should happen as part of the 1.4.2 bugfix release. I don't know if that implies a break of compatibility?

@hugovk your thoughts?

