### PR TITLE
Revert "Fix bitrate parsing for cross-platform environment"

### DIFF
--- a/sox/file_info.py
+++ b/sox/file_info.py
@@ -56,17 +56,13 @@ def bitrate(input_filepath: Union[str, Path]) -> Optional[float]:
     validate_input_file(input_filepath)
     output = soxi(input_filepath, 'B')
     # The characters below stand for kilo, Mega, Giga, etc.
-    # greek_prefix might not be the last character in string in cross platform
-    # environment - \r\n
-    greek_prefixes = '\0KMGTPEZY'
-    greek_index = [n for n, p in enumerate(greek_prefixes) if p in output.upper()]
+    greek_prefixes = '\0kMGTPEZY'
     if output == "0":
         logger.warning("Bit rate unavailable for %s", input_filepath)
         return None
-    elif greek_index:
-        assert len(greek_index) == 1
-        multiplier = 1000.0**greek_index[0]
-        return float(output[:greek_index[0]])*multiplier
+    elif output[-1] in greek_prefixes:
+        multiplier = 1000.0**(greek_prefixes.index(output[-1]))
+        return float(output[:-1])*multiplier
     else:
         return float(output[:-1])
 


### PR DESCRIPTION
Reverts rabitt/pysox#140

@nullptr-0 PR #140 passed your test but broke other tests!


```python
____________________________ TestBitrate.test_aiff _____________________________

self = <test_file_info.TestBitrate testMethod=test_aiff>

    def test_aiff(self):
        actual = file_info.bitrate(INPUT_FILE2)
        expected = 768000.0
>       self.assertEqual(expected, actual)
E       AssertionError: 768000.0 != 7000.0

tests/test_file_info.py:64: AssertionError
_____________________________ TestBitrate.test_wav _____________________________

self = <test_file_info.TestBitrate testMethod=test_wav>

    def test_wav(self):
        actual = file_info.bitrate(INPUT_FILE)
        expected = 706000.0
>       self.assertEqual(expected, actual)
E       AssertionError: 706000.0 != 7000.0

tests/test_file_info.py:54: AssertionError
_________________________ TestBitrate.test_wav_pathlib _________________________

self = <test_file_info.TestBitrate testMethod=test_wav_pathlib>

    def test_wav_pathlib(self):
        actual = file_info.bitrate(Path(INPUT_FILE))
        expected = 706000.0
>       self.assertEqual(expected, actual)
E       AssertionError: 706000.0 != 7000.0

tests/test_file_info.py:59: AssertionError
___________________________ TestInfo.test_dictionary ___________________________

self = <test_file_info.TestInfo testMethod=test_dictionary>

    def test_dictionary(self):
        for use_pathlib in [False, True]:
            with self.subTest():
                input_file = Path(INPUT_FILE) if use_pathlib else INPUT_FILE
    
                actual = file_info.info(input_file)
                expected = {
                    'channels': 1,
                    'sample_rate': 44100.0,
                    'bitdepth': 16,
                    'bitrate': 706000.0,
                    'duration': 10.0,
                    'num_samples': 441000,
                    'encoding': 'Signed Integer PCM',
                    'silent': False
                }
>               self.assertEqual(expected, actual)
E               AssertionError: {'cha[59 chars]': 706000.0, 'duration': 10.0, 'num_samples': [53 chars]alse} != {'cha[59 chars]': 7000.0, 'duration': 10.0, 'num_samples': 44[51 chars]alse}
E                 {'bitdepth': 16,
E               -  'bitrate': 706000.0,
E               ?              --
E               
E               +  'bitrate': 7000.0,
E                  'channels': 1,
E                  'duration': 10.0,
E                  'encoding': 'Signed Integer PCM',
E                  'num_samples': 441000,
E                  'sample_rate': 44100.0,
E                  'silent': False}

tests/test_file_info.py:[34](https://github.com/rabitt/pysox/actions/runs/8215704930/job/22469464052#step:6:35)6: AssertionError
```

reverting for now
